### PR TITLE
Add Boa base objects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,10 +67,7 @@ jobs:
       run: bundle exec rake test
 
     - name: Run mutation tests
-      run: |
-        if [ -d lib ]; then
-          bundle exec mutant run --since main
-        fi
+      run: bundle exec mutant run --since main
 
     - name: Run docs tests
       run: bundle exec yard doctest

--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,6 +1,8 @@
 ---
 integration:
   name: minitest
+requires:
+  - boa
 includes:
   - test
 mutation:
@@ -8,3 +10,8 @@ mutation:
 matcher:
   subjects:
     - Boa*
+  ignore:
+    - Boa#model                     # T.unsafe is removed, but is required by sorbet
+    - Boa::ClassMethods#properties  # T.nilable is removed, but is required by sorbet
+    - Boa::Equality#eql?            # T.nilable is removed, but is required by sorbet
+    - Boa::Type#initialize          # T.nilable is removed, but is required by sorbet

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,7 +89,9 @@ Style/MethodCallWithArgsParentheses:
   AllowedMethods:
     - describe
     - it
+    - public_constant
     - require
+    - require_relative
   EnforcedStyle: require_parentheses
   Exclude:
     - .simplecov

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,10 @@ Metrics/MethodLength:
 Naming/BlockForwarding:
   EnforcedStyle: explicit
 
+Security/CompoundHash:
+  Exclude:
+    - lib/boa/equality.rb
+
 Sorbet/RedundantExtendTSig:
   Enabled: false
 
@@ -87,8 +91,15 @@ Style/InlineComment:
 
 Style/MethodCallWithArgsParentheses:
   AllowedMethods:
+    - attr_reader
+    - attr_writer
+    - cover
     - describe
+    - extend
+    - include
     - it
+    - prop
+    - protected
     - public_constant
     - require
     - require_relative
@@ -98,6 +109,10 @@ Style/MethodCallWithArgsParentheses:
     - Gemfile
   IgnoreMacros: false
 
+Style/MixinUsage:
+  Exclude:
+    - spec/doctest_helper.rb
+
 Style/RequireOrder:
   Enabled: false
 
@@ -105,3 +120,7 @@ Style/StringLiterals:
   EnforcedStyle: single_quotes
   Exclude:
     - sorbet/rbi/*.rbi
+
+Style/TopLevelMethodDefinition:
+  Exclude:
+    - spec/doctest_helper.rb

--- a/boa.gemspec
+++ b/boa.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'lib/boa/version'
+
 Gem::Specification.new do |spec|
   spec.name        = 'boa'
-  spec.version     = '0.1.0'
+  spec.version     = Boa::VERSION
   spec.authors     = ['Dan Kubb']
   spec.email       = %w[github@dan.kubb.ca]
   spec.summary     = 'A Ruby gem for defining immutable, strongly-typed data structures with built-in validation.'
@@ -10,7 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/dkubb/boa'
   spec.license     = 'MIT'
 
-  spec.files = %w[LICENSE README.md]
+  spec.files         = Dir['lib/**/*'] | %w[LICENSE README.md]
+  spec.require_paths = %w[lib]
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 

--- a/lib/boa.rb
+++ b/lib/boa.rb
@@ -1,0 +1,88 @@
+# typed: strong
+# frozen_string_literal: true
+
+require 'ice_nine'
+require 'sorbet-runtime'
+
+require_relative 'boa/equality'
+require_relative 'boa/class_methods'
+require_relative 'boa/type'
+require_relative 'boa/type/object'
+require_relative 'boa/type/boolean'
+require_relative 'boa/type/string'
+require_relative 'boa/version'
+
+# The Boa base module
+module Boa
+  extend T::Sig
+  extend T::Helpers
+  include Equality
+
+  # The error raised when an unknown attribute is provided
+  class UnknownAttributeError < ArgumentError
+    extend T::Sig
+
+    # Initialize the error
+    #
+    # @param unknown [Array<Symbol>] the unknown attributes
+    #
+    # @return [void]
+    #
+    # @api private
+    sig { params(unknown: T::Array[Symbol]).void }
+    def initialize(unknown)
+      super("Unknown attributes: #{unknown.sort.join(', ')}")
+    end
+  end
+
+  mixes_in_class_methods(ClassMethods)
+
+  abstract!
+
+  # Initialize the object
+  #
+  # @example
+  #   person = Person.new(name: 'Dan')
+  #   person.class  # => Person
+  #   person.name   # => 'Dan'
+  #
+  # @param attributes [Hash{Symbol => Object}] the attributes to initialize with
+  #
+  # @return [void]
+  #
+  # @api public
+  sig { params(attributes: Object).void }
+  def initialize(**attributes)
+    assert_known_attributes(**attributes)
+
+    model.properties.each_value do |type|
+      type.init(T.bind(self, Object), **attributes)
+    end
+  end
+
+  private
+
+  # The model of the object
+  #
+  # @return [ClassMethods] the model of the object
+  #
+  # @api private
+  sig { returns(ClassMethods) }
+  def model
+    # self.class extends the class methods module
+    T.let(T.unsafe(self.class), ClassMethods) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUnsafe
+  end
+
+  # Assert that the attributes are known
+  #
+  # @param attributes [Hash{Symbol => Object}] the attributes to check
+  #
+  # @return [void]
+  #
+  # @api private
+  sig { params(attributes: Object).void }
+  def assert_known_attributes(**attributes)
+    unknown = attributes.keys - model.properties.keys
+    raise(UnknownAttributeError, unknown) if unknown.any?
+  end
+end

--- a/lib/boa/class_methods.rb
+++ b/lib/boa/class_methods.rb
@@ -1,0 +1,96 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  # A module for class methods
+  module ClassMethods
+    extend T::Sig
+    extend T::Helpers
+
+    requires_ancestor { Module }
+
+    abstract!
+
+    # Hook called when the module is included
+    #
+    # @param descendant [Module] the module or class including this module
+    #
+    # @return [void]
+    #
+    # @api private
+    sig { params(descendant: Module).void }
+    def inherited(descendant)
+      descendant.instance_variable_set(:@properties, properties.dup)
+
+      super
+    end
+
+    # The properties for this type
+    #
+    # @return [Hash{Symbol => Type}] the properties for this type
+    #
+    # @api private
+    sig { returns(T::Hash[Symbol, Type]) }
+    def properties
+      @properties ||= T.let({}, T.nilable(T::Hash[Symbol, Type]))
+    end
+
+    # A DSL method to set up the properties
+    #
+    # @example
+    #   klass  = Class.new { include Boa }
+    #   result = klass.prop :last_name, Boa::Type::String
+    #   klass.equal?(result)                               # => true
+    #
+    # @param name [Symbol] the name of the property
+    # @param type [Type] the type of the property
+    #
+    # @return [ClassMethods] the class method module
+    #
+    # @api public
+    sig { params(name: Symbol, type: T::Class[Type], required: T::Boolean, options: Object).returns(T.self_type) }
+    def prop(name, type, required: true, **options)
+      properties[name] = type.new(name, required:, **options)
+      self
+    end
+
+    # Finalize the class methods
+    #
+    # @example
+    #   klass = Class.new { include Boa }
+    #   klass.finalize.frozen?             # => true
+    #
+    # @return [ClassMethods] the class method module
+    #
+    # @api public
+    sig { returns(T.self_type) }
+    def finalize
+      properties.each_value do |type|
+        type.add_methods(T.bind(self, Module)).finalize
+      end
+
+      freeze
+    end
+
+    # Deep freeze the class state
+    #
+    # @example
+    #   klass = Class.new { include Boa }
+    #   klass.freeze
+    #   klass.frozen? # => true
+    #
+    # @return [ClassMethods] the class method module
+    #
+    # @api public
+    sig { returns(T.self_type) }
+    def freeze
+      T.let(properties.each_value(&:freeze), T::Hash[Symbol, Type])
+
+      instance_variables.each do |ivar_name|
+        T.let(instance_variable_get(ivar_name), Object).freeze
+      end
+
+      T.let(super(), ClassMethods)
+    end
+  end
+end

--- a/lib/boa/equality.rb
+++ b/lib/boa/equality.rb
@@ -1,0 +1,79 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  # A module for comparing objects for equality
+  module Equality
+    extend T::Sig
+    extend T::Helpers
+
+    requires_ancestor { Object }
+
+    abstract!
+
+    # Compare the object with other object for equivalency
+    #
+    # @example when the objects are equal
+    #   equality_object == equality_object  # => true
+    #
+    # @example when the objects are not equal
+    #   equality_object == other  # => false
+    #
+    # @param [Equality] other
+    #   the other object to compare with
+    #
+    # @return [Boolean]
+    #
+    # @api public
+    sig { params(other: Equality).returns(T::Boolean) }
+    def ==(other)
+      other.is_a?(self.class) && object_state == other.object_state
+    end
+
+    # Compare the object with other object for equality
+    #
+    # @example when the objects are equal
+    #   equality_object.eql?(equality_object)  # => true
+    #
+    # @example when the objects are not equal
+    #   equality_object.eql?(other)  # => false
+    #
+    # @param [Equality] other
+    #   the other object to compare with
+    #
+    # @return [Boolean]
+    #
+    # @api public
+    sig { params(other: Equality).returns(T::Boolean) }
+    def eql?(other)
+      other.instance_of?(self.class) && T.let(object_state.eql?(other.object_state), T.nilable(T::Boolean)).equal?(true)
+    end
+
+    # The hash value of the object
+    #
+    # @example
+    #   equality_object.hash.class  # => Integer
+    #
+    # @return [Integer] the hash value of the object
+    #
+    # @api public
+    sig { returns(Integer) }
+    def hash
+      self.class.hash ^ T.let(object_state.hash, Integer)
+    end
+
+    protected
+
+    # The state of the object
+    #
+    # @return [Hash{Symbol => Object}] the state of the object
+    #
+    # @api private
+    sig { overridable.returns(T::Hash[Symbol, ::Object]) }
+    def object_state
+      instance_variables.to_h do |ivar_name|
+        [ivar_name, instance_variable_get(ivar_name)]
+      end
+    end
+  end
+end

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -1,0 +1,210 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  # Abstract class for types
+  class Type
+    extend T::Sig
+    extend T::Helpers
+    include Equality
+
+    abstract!
+
+    # The name of the instance variable
+    #
+    # @example
+    #   type.name  # => :first_name
+    #
+    # @return [Symbol] the name of the instance variable
+    #
+    # @api public
+    sig { returns(Symbol) }
+    attr_reader :name
+
+    # The required flag of the type
+    #
+    # @example
+    #   type.required  # => true
+    #
+    # @return [Boolean] the required flag of the type
+    #
+    # @api public
+    sig { returns(T::Boolean) }
+    attr_reader :required
+
+    # @example
+    #   type.required?  # => true
+    #
+    # @return [Boolean] the required flag of the type
+    #
+    # @api public
+    alias required? required
+
+    # The default value of the type
+    #
+    # @example
+    #   type.default  # => 'Jon'
+    #
+    # @return [Object] the default value of the type
+    #
+    # @api public
+    sig { returns(::Object) }
+    attr_reader :default
+
+    # The object to check inclusion against
+    #
+    # @example
+    #   type.includes  # => nil
+    #
+    # @return [Object] the object to check inclusion against
+    #
+    # @api public
+    sig { returns(::Object) }
+    attr_reader :includes
+
+    # The name of the instance variable
+    #
+    # @example
+    #   type.ivar_name  # => :@first_name
+    #
+    # @return [Symbol] the name of the instance variable
+    #
+    # @api public
+    sig { returns(Symbol) }
+    attr_reader :ivar_name
+
+    # Initialize the type
+    #
+    # @param name [Symbol] the name of the type
+    # @param required [Boolean] whether the type is required
+    # @param default [Object] the default value of the type
+    # @param includes [Object] the object to check inclusion against
+    # @param ivar_name [Symbol] the name of the instance variable
+    #
+    # @yield [] the block to instance_eval
+    #
+    # @return [void]
+    #
+    # @api private
+    sig { params(name: Symbol, required: T::Boolean, default: ::Object, includes: ::Object, ivar_name: Symbol).void }
+    def initialize(name, required: true, default: nil, includes: nil, ivar_name: :"@#{name}")
+      @name      = name
+      @required  = required
+      @default   = T.let(default, T.nilable(::Object))
+      @includes  = T.let(includes, T.nilable(::Object))
+      @ivar_name = ivar_name
+    end
+
+    # Initialize the attribute in the instance
+    #
+    # @example with no attributes
+    #   type.get(instance)   # => nil
+    #   type.init(instance)  # => type   # set the default value
+    #   type.get(instance)   # => 'Jon'
+    #
+    # @example with attributes
+    #   type.get(instance)                       # => nil
+    #   type.init(instance, first_name: 'Alex')  # => type  # set the value
+    #   type.get(instance)                       # => 'Alex'
+    #
+    # @param instance [::Object] the instance to initialize
+    # @param attributes [Hash{Symbol => ::Object}] the attributes to initialize with
+    #
+    # @return [Type] the type
+    #
+    # @api public
+    sig { params(instance: ::Object, attributes: ::Object).returns(T.self_type) }
+    def init(instance, **attributes)
+      value = attributes.fetch(name) { default }
+      set(instance, value)
+    end
+
+    # Get the value of the attribute from the instance
+    #
+    # @example when the value is not set
+    #   type.get(instance)  # => nil  # get the value
+    #
+    # @example when the value is set
+    #   type.set(instance, 'Alex')  # => type
+    #   type.get(instance)          # => 'Alex'  # get the value
+    #
+    # @param instance [::Object] the instance to get the value from
+    #
+    # @return [::Object] the value of the attribute
+    #
+    # @api public
+    sig { params(instance: ::Object).returns(::Object) }
+    def get(instance)
+      instance.instance_variable_get(ivar_name)
+    end
+
+    # Set the value of the attribute in the instance
+    #
+    # @example
+    #   type.get(instance)          # => nil
+    #   type.set(instance, 'Alex')  # => type    # set the value
+    #   type.get(instance)          # => 'Alex'
+    #
+    # @param instance [::Object] the instance to set the value in
+    # @param value [::Object] the value to set
+    #
+    # @return [Type] the type
+    #
+    # @api public
+    sig { params(instance: ::Object, value: ::Object).returns(T.self_type) }
+    def set(instance, value)
+      instance.instance_variable_set(ivar_name, value)
+      self
+    end
+
+    # Add methods to the descendant
+    #
+    # @example
+    #   descendant.new.respond_to?(:first_name)  # => false
+    #   type.add_methods(descendant)             # => type
+    #   descendant.new.respond_to?(:first_name)  # => true
+    #
+    # @param descendant [Module] the class to add the methods to
+    #
+    # @return [Type] the type
+    #
+    # @api public
+    sig { params(descendant: Module).returns(T.self_type) }
+    def add_methods(descendant)
+      add_reader(descendant)
+    end
+
+    # Finalize the type
+    #
+    # @example
+    #   type.frozen?   # => false
+    #   type.finalize  # => type   # freeze the type
+    #   type.frozen?   # => true
+    #
+    # @return [Type] the type
+    #
+    # @api public
+    sig { returns(T.self_type) }
+    def finalize
+      freeze
+    end
+
+    private
+
+    # Add a reader method to the descendant
+    #
+    # @param descendant [Module] the class to add the method to
+    #
+    # @return [Type] the type
+    #
+    # @api private
+    sig { params(descendant: Module).returns(T.self_type) }
+    def add_reader(descendant)
+      type = self
+      descendant.define_method(name) do
+        type.get(T.bind(self, ::Object))
+      end
+      type
+    end
+  end
+end

--- a/lib/boa/type/boolean.rb
+++ b/lib/boa/type/boolean.rb
@@ -1,0 +1,53 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  class Type
+    # A boolean type
+    class Boolean < Object
+      # Initialize the boolean type
+      #
+      # @example
+      #   type = Boolean.new(:admin?)
+      #   type.class  # => Boolean
+      #   type.name   # => :admin?
+      #
+      # @param _name [Symbol] the name of the type
+      # @param includes [Array<Boolean>] the object to check inclusion against
+      # @param options [Hash] the options to initialize with
+      #
+      # @return [void]
+      #
+      # @api public
+      sig { params(_name: Symbol, includes: T::Array[T::Boolean], options: ::Object).void }
+      def initialize(_name, includes: [true, false], **options)
+        super
+      end
+
+      private
+
+      # Add reader methods to the descendant
+      #
+      # @example
+      #   descendant.new.respond_to?(:author?)  # => false
+      #   type.add_methods(descendant)          # => type
+      #   descendant.new.respond_to?(:author?)  # => true
+      #
+      # @param descendant [ClassMethods] the class to add methods to
+      #
+      # @return [Type] the type
+      #
+      # @api private
+      sig { params(descendant: Module).returns(T.self_type) }
+      def add_reader(descendant)
+        name = name()
+        descendant.define_method(:"#{name}?") do
+          boolean = T.let(public_send(name), T.nilable(T::Boolean))
+          boolean.equal?(true)
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/lib/boa/type/object.rb
+++ b/lib/boa/type/object.rb
@@ -1,0 +1,10 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  class Type
+    # An object type
+    class Object < self
+    end
+  end
+end

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -1,0 +1,95 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  class Type
+    # A string type
+    class String < Object
+      # The length of the string
+      #
+      # @example
+      #   type.length  # => 1..
+      #
+      # @return [Range<Integer>] the length of the string
+      #
+      # @api public
+      sig { returns(T::Range[Integer]) }
+      attr_reader :length
+
+      # Initialize the string type
+      #
+      # @example with the default length and default
+      #   type = String.new(:name)
+      #   type.class   # => String
+      #   type.name    # => :name
+      #   type.length  # => 1..
+      #   type.default # => nil
+      #
+      # @example with a custom length
+      #   type = String.new(:name, length: 1..50)
+      #   type.class   # => String
+      #   type.name    # => :name
+      #   type.length  # => 1..50
+      #   type.default # => nil
+      #
+      # @example with a custom default
+      #   type = String.new(:name, default: 'Dan Kubb')
+      #   type.class   # => String
+      #   type.name    # => :name
+      #   type.length  # => 1..
+      #   type.default # => 'Dan Kubb'
+      #
+      # @example with a nil minimum length
+      #   String.new(:name, length: nil..50)  # => raise ArgumentError, 'length.begin cannot be nil'
+      #
+      # @param name [Symbol] the name of the type
+      # @param length [Range<Integer>] the length of the string
+      # @param options [Hash{Symbol => Object}] the options for the type
+      #
+      # @return [void]
+      #
+      # @api public
+      sig { params(name: Symbol, required: T::Boolean, length: T::Range[Integer], options: ::Object).void }
+      def initialize(name, required: true, length: 1.., **options)
+        raise(ArgumentError, 'length.begin cannot be nil') if length.begin.nil?
+
+        @length = T.let(length, T::Range[Integer])
+
+        super(name, required:, **options)
+      end
+
+      # The minimum length of the string
+      #
+      # @example
+      #   type = String.new(:name)
+      #   type.min_length  # => 1
+      #
+      # @return [Integer] the minimum length of the string
+      #
+      # @api public
+      sig { returns(Integer) }
+      def min_length
+        length.begin
+      end
+
+      # The maximum length of the string
+      #
+      # @example with no maximum length
+      #   type = String.new(:name)
+      #   type.max_length  # => nil
+      #
+      # @example with a maximum length
+      #   type = String.new(:name, length: 1..50)
+      #   type.max_length  # => 50
+      #
+      # @return [Integer, nil] the maximum length of the string
+      #
+      # @api public
+      sig { returns(T.nilable(Integer)) }
+      def max_length
+        max_length = T.assert_type!(length.end, T.nilable(Integer))
+        length.exclude_end? && max_length ? max_length - 1 : max_length
+      end
+    end
+  end
+end

--- a/lib/boa/version.rb
+++ b/lib/boa/version.rb
@@ -1,0 +1,8 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Boa
+  # The Boa version
+  VERSION = '0.1.0'
+  public_constant :VERSION
+end

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,5 +1,6 @@
 --dir=.
 --enable-experimental-requires-ancestor
 --ignore=sorbet/
+--ignore=spec/
 --ignore=tmp/
 --ignore=vendor/

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -1,0 +1,78 @@
+# typed: strong
+# frozen_string_literal: true
+
+require 'simplecov'
+require 'sorbet-runtime'
+
+require 'boa'
+
+extend T::Sig
+
+class Person
+  include Boa
+
+  prop :name,  Type::String, default: 'Dan Kubb', length: 1..50
+  prop :email, Type::String
+  prop :admin, Type::Boolean, default: false
+
+  finalize
+end
+
+sig { returns(Boa) }
+def instance
+  @instance ||= T.assert_type!(Person.new, T.nilable(Person))
+end
+
+sig { returns(Boa::Type) }
+def type
+  @type ||= T.assert_type!(Class.new(Boa::Type).new(:first_name, default: 'Jon'), T.nilable(Boa::Type))
+end
+
+sig { returns(T::Class[Boa]) }
+def descendant
+  @descendant ||= T.assert_type!(Class.new { include Boa }, T.nilable(T::Class[Boa]))
+end
+
+sig { returns(T::Class[Boa::Equality]) }
+def equality_class
+  @equality_class ||=
+    Class.new do
+      extend T::Sig
+      include Boa::Equality
+
+      protected
+
+      sig { override.returns(T::Hash[Symbol, Object]) }
+      def object_state
+        { object_id: }
+      end
+    end
+end
+
+sig { returns(Boa::Equality) }
+def equality_object
+  @equality_object ||= T.assert_type!(equality_class.new, T.nilable(Boa::Equality))
+end
+
+sig { returns(Object) }
+def other
+  @other ||= Object.new
+end
+
+YARD::Doctest.configure do |doctest|
+  doctest.before('Boa::Equality') do
+    @other = T.assert_type!(equality_class.new, T.nilable(Boa::Equality))
+  end
+
+  doctest.before('Boa::Type::Boolean') do
+    @type = Boa::Type::Boolean.new(:author)
+  end
+
+  doctest.before('Boa::Type::String') do
+    @type = Boa::Type::String.new(:first_name)
+  end
+
+  doctest.before do
+    @instance = nil
+  end
+end

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -1,0 +1,451 @@
+# typed: false
+# frozen_string_literal: true
+
+module Support
+  module TypeBehaviour
+    module New
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Type#initialize'
+
+          it 'sets the name attribute' do
+            assert_equal(type_name, subject.name)
+          end
+
+          describe 'with no required option' do
+            it 'sets the required attribute to the default' do
+              assert_operator(subject, :required)
+            end
+          end
+
+          describe 'with a required option' do
+            subject { described_class.new(type_name, required:) }
+
+            describe 'with a true value' do
+              sig { returns(T::Boolean) }
+              def required
+                true
+              end
+
+              it 'sets the required attribute to true' do
+                assert_operator(subject, :required)
+              end
+            end
+
+            describe 'with a false value' do
+              sig { returns(T::Boolean) }
+              def required
+                false
+              end
+
+              it 'sets the required attribute to false' do
+                refute_operator(subject, :required)
+              end
+            end
+          end
+
+          describe 'with no default option' do
+            it 'sets the default attribute to the default' do
+              assert_nil(subject.default)
+            end
+          end
+
+          describe 'with a default option' do
+            subject { described_class.new(type_name, default: non_nil_default) }
+
+            describe 'with a non-nil value' do
+              it 'sets the default attribute' do
+                assert_equal(non_nil_default, subject.default)
+              end
+            end
+          end
+
+          describe 'with no includes option' do
+            it 'sets the includes attribute to the default' do
+              if default_includes.nil?
+                assert_nil(subject.includes)
+              else
+                assert_equal(default_includes, subject.includes)
+              end
+            end
+          end
+
+          describe 'with an includes option' do
+            subject { described_class.new(type_name, includes: [true]) }
+
+            it 'sets the includes attribute' do
+              assert_equal([true], subject.includes)
+            end
+          end
+
+          describe 'with no ivar_name option' do
+            it 'sets the ivar_name attribute to the default' do
+              assert_equal(:"@#{type_name}", subject.ivar_name)
+            end
+          end
+
+          describe 'with an ivar_name option' do
+            subject { described_class.new(type_name, ivar_name: :@custom) }
+
+            it 'sets the ivar_name attribute' do
+              assert_equal(:@custom, subject.ivar_name)
+            end
+          end
+        end
+      end
+    end
+
+    module Init
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Type#init'
+
+          sig { returns(Object) }
+          def object
+            @object ||= Object.new
+          end
+
+          describe 'when the key exists in the attributes' do
+            it 'initializes the object' do
+              assert_nil(subject.get(object))
+
+              subject.init(object, subject.name => value)
+
+              assert_same(value, subject.get(object))
+            end
+
+            it 'returns self' do
+              assert_same(subject, subject.init(object, subject.name => value))
+            end
+          end
+
+          describe 'when the key does not exist in the attributes' do
+            describe 'when there is a default' do
+              subject { described_class.new(type_name, default: value) }
+
+              it 'initializes the object with the default' do
+                assert_nil(subject.get(object))
+
+                subject.init(object)
+
+                assert_same(value, subject.get(object))
+              end
+
+              it 'returns self' do
+                assert_same(subject, subject.init(object))
+              end
+            end
+
+            describe 'when there is no default' do
+              it 'does not initialize the object' do
+                assert_nil(subject.get(object))
+
+                subject.init(object)
+
+                assert_nil(subject.get(object))
+              end
+
+              it 'returns self' do
+                assert_same(subject, subject.init(object))
+              end
+            end
+          end
+        end
+      end
+    end
+
+    module Get
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Type#get'
+
+          sig { returns(Object) }
+          def object
+            @object ||= Object.new
+          end
+
+          describe 'when the instance variable exists in the object' do
+            before do
+              subject.init(object, subject.name => value)
+            end
+
+            it 'returns the value' do
+              assert_same(value, subject.get(object))
+            end
+          end
+
+          describe 'when the instance variable does not exist in the object' do
+            it 'returns nil' do
+              assert_nil(subject.get(object))
+            end
+          end
+        end
+      end
+    end
+
+    module Set
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Type#set'
+
+          sig { returns(Object) }
+          def object
+            @object ||= Object.new
+          end
+
+          sig { returns(Object) }
+          def new_value
+            @new_value ||= value.dup
+          end
+
+          describe 'when the instance variable exists in the object' do
+            before do
+              subject.init(object, subject.name => value)
+            end
+
+            it 'sets the object' do
+              assert_same(value, subject.get(object))
+
+              subject.set(object, new_value)
+
+              assert_same(new_value, subject.get(object))
+            end
+
+            it 'returns self' do
+              assert_same(subject, subject.init(object, subject.name => value))
+            end
+          end
+
+          describe 'when the instance variable does not exist in the object' do
+            it 'returns nil' do
+              assert_nil(subject.get(object))
+
+              subject.set(object, new_value)
+
+              assert_same(new_value, subject.get(object))
+            end
+          end
+        end
+      end
+    end
+
+    module Equality
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Equality#=='
+
+          describe 'when the types have the same name and options' do
+            it 'returns true' do
+              assert_equal(subject, other)
+            end
+          end
+
+          describe 'when the types have different names and same options' do
+            sig { returns(Symbol) }
+            def other_type_name
+              :other
+            end
+
+            it 'returns false' do
+              refute_equal(subject, other)
+            end
+          end
+
+          describe 'when the types have the same name and options, but one is subclass' do
+            it 'returns true' do
+              subclass = Class.new(described_class)
+
+              assert_equal(subject, subclass.new(other_type_name, **other_options))
+            end
+          end
+
+          describe 'when the types have the same name and options, but one is not a subclass' do
+            it 'returns true' do
+              sibling_class = Class.new(Boa::Type)
+
+              refute_equal(subject, sibling_class.new(other_type_name, **other_options))
+            end
+          end
+
+          describe 'when the types have the same name and different options' do
+            sig { returns(T::Hash[Symbol, Object]) }
+            def other_options
+              { required: false }
+            end
+
+            it 'returns false' do
+              refute_equal(subject, other)
+            end
+          end
+        end
+      end
+    end
+
+    module Eql
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Equality#eql?'
+
+          describe 'when the types have the same name and options' do
+            it 'returns true' do
+              assert_operator(subject, :eql?, other)
+            end
+          end
+
+          describe 'when the types have different names and same options' do
+            sig { returns(Symbol) }
+            def other_type_name
+              :other
+            end
+
+            it 'returns false' do
+              refute_operator(subject, :eql?, other)
+            end
+          end
+
+          describe 'when the types have the same name and different options' do
+            sig { returns(T::Hash[Symbol, Object]) }
+            def other_options
+              { required: false }
+            end
+
+            it 'returns false' do
+              refute_operator(subject, :eql?, other)
+            end
+          end
+
+          describe 'when the types have the same name and options, but one is subclass' do
+            it 'returns false' do
+              subclass = Class.new(described_class)
+
+              refute_operator(subject, :eql?, subclass.new(other_type_name, **other_options))
+            end
+          end
+        end
+      end
+    end
+
+    module Hash
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Equality#hash'
+
+          it 'returns an integer' do
+            assert_kind_of(Integer, subject.hash)
+          end
+
+          it 'returns the same value for equal objects' do
+            assert_equal(subject.hash, other.hash)
+          end
+
+          it 'returns the different values for different objects' do
+            other = described_class.new(type_name, required: false)
+
+            refute_equal(subject.hash, other.hash)
+          end
+
+          it 'returns different values for objects with the same name and options, but one is subclass' do
+            subclass = Class.new(described_class)
+            other    = subclass.new(other_type_name)
+
+            refute_equal(subject.hash, other.hash)
+          end
+        end
+      end
+    end
+
+    module AddMethods
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Type#add_methods'
+
+          sig { returns(T::Class[Boa]) }
+          def klass
+            @klass ||= Class.new { include Boa }
+          end
+
+          before do
+            klass.properties[type_name] = subject
+          end
+
+          describe 'when the ivar is not nil' do
+            it 'adds a reader method' do
+              instance = klass.new(type_name => value)
+
+              refute_respond_to(instance, type_name)
+
+              subject.add_methods(klass)
+
+              assert_respond_to(instance, type_name)
+              assert_same(value, instance.public_send(type_name))
+            end
+
+            it 'returns self' do
+              assert_same(subject, subject.add_methods(klass))
+            end
+          end
+
+          describe 'when the ivar is nil' do
+            it 'adds a reader method' do
+              instance = klass.new
+
+              refute_respond_to(instance, type_name)
+
+              subject.add_methods(klass)
+
+              assert_respond_to(instance, type_name)
+              assert_nil(instance.public_send(type_name))
+            end
+
+            it 'returns self' do
+              assert_same(subject, subject.add_methods(klass))
+            end
+          end
+        end
+      end
+    end
+
+    module Finalize
+      extend T::Sig
+
+      sig { params(descendant: Module).void }
+      def self.included(descendant)
+        descendant.class_eval do
+          cover 'Boa::Type#finalize'
+
+          it 'freezes the type' do
+            refute_operator(subject, :frozen?)
+
+            subject.finalize
+
+            assert_operator(subject, :frozen?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,15 @@ require 'simplecov'
 require 'minitest/autorun'
 require 'mutant/minitest/coverage'
 require 'sorbet-runtime'
+
+require_relative 'support/type_behaviour'
+
+require 'boa'
+
+class Person
+  include Boa
+
+  prop :name, Boa::Type::String
+
+  finalize
+end

--- a/test/unit/boa/class_methods_test.rb
+++ b/test/unit/boa/class_methods_test.rb
@@ -1,0 +1,149 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Boa::ClassMethods do
+  extend T::Sig
+
+  subject do
+    Class.new do
+      extend Boa::ClassMethods
+
+      prop :name, Boa::Type::String
+    end
+  end
+
+  describe '#inherited' do
+    cover 'Boa::ClassMethods#inherited'
+
+    it 'copies the properties' do
+      subclass = Class.new(subject)
+
+      assert_equal(subject.properties, subclass.properties)
+      refute_same(subject.properties, subclass.properties)
+    end
+
+    it 'calls the superclass inherited method' do
+      called_with  = nil
+
+      subject.singleton_class.superclass.define_method(:inherited) do |descendant|
+        called_with = descendant
+      end
+
+      subclass = Class.new(subject)
+
+      assert_same(subclass, called_with)
+    end
+  end
+
+  describe '#properties' do
+    cover 'Boa::ClassMethods#properties'
+
+    it 'returns the properties' do
+      assert_equal({ name: Boa::Type::String.new(:name) }, subject.properties)
+    end
+  end
+
+  describe '#prop' do
+    cover 'Boa::ClassMethods#prop'
+
+    sig { returns(T::Hash[Symbol, Object]) }
+    def options
+      { required: false, default: false }
+    end
+
+    it 'sets the property' do
+      subject.prop(:admin, Boa::Type::Boolean, **options)
+
+      assert_equal({ name: Boa::Type::String.new(:name), admin: Boa::Type::Boolean.new(:admin, **options) }, subject.properties)
+    end
+
+    it 'returns self' do
+      assert_same(subject, subject.prop(:admin, Boa::Type::Boolean, **options))
+    end
+  end
+
+  describe '#finalize' do
+    cover 'Boa::ClassMethods#finalize'
+
+    it 'adds the methods to the class' do
+      refute_respond_to(subject.new, :name)
+
+      subject.finalize
+
+      assert_respond_to(subject.new, :name)
+    end
+
+    it 'finalizes the types' do
+      finalized = false
+
+      subject
+        .properties
+        .fetch(:name)
+        .define_singleton_method(:finalize) { finalized = true }
+
+      refute(finalized)
+
+      subject.finalize
+
+      assert(finalized)
+    end
+
+    it 'freezes the class' do
+      refute_operator(subject, :frozen?)
+
+      subject.finalize
+
+      assert_operator(subject, :frozen?)
+    end
+
+    it 'returns the class' do
+      assert_same(subject, subject.finalize)
+    end
+  end
+
+  describe '#freeze' do
+    cover 'Boa::ClassMethods#freeze'
+
+    before do
+      subject.class_eval { @ivar = +'value' }
+    end
+
+    it 'freezes type of each property' do
+      type = subject.properties.fetch(:name)
+
+      refute_operator(type, :frozen?)
+
+      subject.freeze
+
+      assert_operator(type, :frozen?)
+    end
+
+    it 'freezes the properties' do
+      refute_operator(subject.properties, :frozen?)
+
+      subject.freeze
+
+      assert_operator(subject.properties, :frozen?)
+    end
+
+    it 'freezes the instance variables' do
+      ivar = subject.instance_variable_get(:@ivar)
+
+      refute_operator(ivar, :frozen?)
+
+      subject.freeze
+
+      assert_operator(ivar, :frozen?)
+    end
+
+    it 'freezes the class' do
+      assert_operator(subject.freeze, :frozen?)
+    end
+
+    it 'returns the class' do
+      assert_same(subject, subject.finalize)
+    end
+  end
+end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -1,0 +1,155 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Boa::Type::Boolean do
+  extend T::Sig
+
+  subject { described_class.new(type_name) }
+
+  sig { returns(T::Class[Boa::Type]) }
+  def described_class
+    Boa::Type::Boolean
+  end
+
+  sig { returns(Symbol) }
+  def type_name
+    :admin
+  end
+
+  sig { returns(T::Boolean) }
+  def value
+    false
+  end
+
+  sig { returns(Boa::Type) }
+  def other
+    described_class.new(other_type_name, **other_options)
+  end
+
+  sig { returns(Symbol) }
+  def other_type_name
+    type_name
+  end
+
+  sig { returns(T::Hash[Symbol, Object]) }
+  def other_options
+    {}
+  end
+
+  describe '.new' do
+    include Support::TypeBehaviour::New
+
+    cover 'Boa::Type::Boolean#initialize'
+
+    sig { returns(T.nilable(Object)) }
+    def default_includes
+      [true, false]
+    end
+
+    sig { returns(T.nilable(Object)) }
+    def non_nil_default
+      true
+    end
+  end
+
+  describe '#init' do
+    include Support::TypeBehaviour::Init
+  end
+
+  describe '#get' do
+    include Support::TypeBehaviour::Get
+  end
+
+  describe '#set' do
+    include Support::TypeBehaviour::Set
+  end
+
+  describe '#==' do
+    include Support::TypeBehaviour::Equality
+  end
+
+  describe '#eql' do
+    include Support::TypeBehaviour::Eql
+  end
+
+  describe '#hash' do
+    include Support::TypeBehaviour::Hash
+  end
+
+  describe '#add_methods' do
+    include Support::TypeBehaviour::AddMethods
+
+    describe 'when the ivar is true' do
+      cover 'Boa::Type::Boolean#add_methods'
+
+      sig { returns(T::Boolean) }
+      def value
+        true
+      end
+
+      it 'adds a query method' do
+        instance = klass.new(type_name => value)
+
+        refute_respond_to(instance, :"#{type_name}?")
+
+        subject.add_methods(klass)
+
+        assert_respond_to(instance, :"#{type_name}?")
+        assert_same(value, instance.admin?)
+      end
+
+      it 'returns self' do
+        assert_same(subject, subject.add_methods(klass))
+      end
+    end
+
+    describe 'when the ivar is false' do
+      cover 'Boa::Type::Boolean#add_methods'
+
+      sig { returns(T::Boolean) }
+      def value
+        false
+      end
+
+      it 'adds a query method' do
+        instance = klass.new(type_name => value)
+
+        refute_respond_to(instance, :"#{type_name}?")
+
+        subject.add_methods(klass)
+
+        assert_respond_to(instance, :"#{type_name}?")
+        assert_same(value, instance.admin?)
+      end
+
+      it 'returns self' do
+        assert_same(subject, subject.add_methods(klass))
+      end
+    end
+
+    describe 'when the ivar is nil' do
+      cover 'Boa::Type::Boolean#add_methods'
+
+      it 'adds a query method' do
+        instance = klass.new
+
+        refute_respond_to(instance, :"#{type_name}?")
+
+        subject.add_methods(klass)
+
+        assert_respond_to(instance, :"#{type_name}?")
+        assert_same(false, instance.admin?)
+      end
+
+      it 'returns self' do
+        assert_same(subject, subject.add_methods(klass))
+      end
+    end
+  end
+
+  describe '#finalize' do
+    include Support::TypeBehaviour::Finalize
+  end
+end

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -1,0 +1,96 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Boa::Type::Object do
+  extend T::Sig
+
+  subject { described_class.new(type_name) }
+
+  sig { returns(T::Class[Boa::Type]) }
+  def described_class
+    Boa::Type::Object
+  end
+
+  sig { returns(Symbol) }
+  def type_name
+    :admin
+  end
+
+  sig { returns(Object) }
+  def value
+    @value ||= Object.new
+  end
+
+  sig { returns(Boa::Type) }
+  def other
+    described_class.new(other_type_name, **other_options)
+  end
+
+  sig { returns(Symbol) }
+  def other_type_name
+    type_name
+  end
+
+  sig { returns(T::Hash[Symbol, Object]) }
+  def other_options
+    {}
+  end
+
+  describe '.new' do
+    include Support::TypeBehaviour::New
+
+    cover 'Boa::Type::Object#initiaize'
+
+    sig { returns(T.nilable(Object)) }
+    def default_includes
+      nil
+    end
+
+    sig { returns(T.nilable(Object)) }
+    def non_nil_default
+      @non_nil_default ||= Object.new
+    end
+  end
+
+  describe '#init' do
+    include Support::TypeBehaviour::Init
+  end
+
+  describe '#get' do
+    include Support::TypeBehaviour::Get
+  end
+
+  describe '#set' do
+    include Support::TypeBehaviour::Set
+  end
+
+  describe '#==' do
+    include Support::TypeBehaviour::Equality
+
+    it 'is false when object state is equal but does not eql?' do
+      subject = described_class.new(type_name, default: 1)
+      other   = described_class.new(type_name, default: 1.0)
+
+      assert_equal(subject, other)
+      refute_operator(subject, :eql?, other)
+    end
+  end
+
+  describe '#eql' do
+    include Support::TypeBehaviour::Eql
+  end
+
+  describe '#hash' do
+    include Support::TypeBehaviour::Hash
+  end
+
+  describe '#add_methods' do
+    include Support::TypeBehaviour::AddMethods
+  end
+
+  describe '#finalize' do
+    include Support::TypeBehaviour::Finalize
+  end
+end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -1,0 +1,211 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Boa::Type::String do
+  extend T::Sig
+
+  subject { described_class.new(type_name) }
+
+  sig { returns(T::Class[Boa::Type]) }
+  def described_class
+    Boa::Type::String
+  end
+
+  sig { returns(Symbol) }
+  def type_name
+    :name
+  end
+
+  sig { returns(String) }
+  def value
+    'value'
+  end
+
+  sig { returns(Boa::Type) }
+  def other
+    described_class.new(other_type_name, **other_options)
+  end
+
+  sig { returns(Symbol) }
+  def other_type_name
+    type_name
+  end
+
+  sig { returns(T::Hash[Symbol, Object]) }
+  def other_options
+    {}
+  end
+
+  describe '.new' do
+    include Support::TypeBehaviour::New
+
+    sig { returns(T.nilable(Object)) }
+    def default_includes
+      nil
+    end
+
+    sig { returns(T.nilable(Object)) }
+    def non_nil_default
+      'Jon'
+    end
+
+    describe 'with no required option' do
+      cover 'Boa::Type::String#initialize'
+
+      subject { described_class.new(type_name) }
+
+      it 'sets the required attribute to true' do
+        assert_operator(subject, :required?)
+      end
+    end
+
+    describe 'with required option' do
+      cover 'Boa::Type::String#initialize'
+
+      subject { described_class.new(type_name, required: false) }
+
+      it 'sets the required attribute to false' do
+        refute_operator(subject, :required?)
+      end
+    end
+
+    describe 'with default option' do
+      cover 'Boa::Type::String#initialize'
+
+      subject { described_class.new(type_name, default: 'default') }
+
+      it 'sets the required attribute' do
+        assert_same('default', subject.default)
+      end
+    end
+
+    describe 'with no length option' do
+      cover 'Boa::Type::String#initialize'
+
+      it 'sets the length attribute to the default' do
+        assert_equal(1.., subject.length)
+      end
+    end
+
+    describe 'with length option' do
+      cover 'Boa::Type::String#initialize'
+
+      subject { described_class.new(type_name, length: min_length..10) }
+
+      describe 'with a non-nil minimum length' do
+        sig { returns(T.nilable(Integer)) }
+        def min_length
+          1
+        end
+
+        it 'sets the length attribute' do
+          assert_equal(1..10, subject.length)
+        end
+      end
+
+      describe 'with a nil minimum length' do
+        sig { returns(T.nilable(Integer)) }
+        def min_length; end
+
+        it 'raises an argument error' do
+          error = assert_raises(ArgumentError) { subject }
+
+          assert_equal('length.begin cannot be nil', error.message)
+        end
+      end
+    end
+  end
+
+  describe '#init' do
+    include Support::TypeBehaviour::Init
+  end
+
+  describe '#get' do
+    include Support::TypeBehaviour::Get
+  end
+
+  describe '#set' do
+    include Support::TypeBehaviour::Set
+  end
+
+  describe '#min_length' do
+    cover 'Boa::Type::String#min_length'
+
+    it 'returns the minimum length' do
+      assert_equal(1, subject.min_length)
+    end
+  end
+
+  describe '#max_length' do
+    cover 'Boa::Type::String#max_length'
+
+    describe 'with no maximum length' do
+      describe 'with an inclusive range' do
+        it 'returns nil' do
+          assert_nil(subject.max_length)
+        end
+      end
+
+      describe 'with an exclusive range' do
+        subject { described_class.new(type_name, length:) }
+
+        sig { returns(T::Range[Integer]) }
+        def length
+          (1...)
+        end
+
+        it 'returns nil' do
+          assert_nil(subject.max_length)
+        end
+      end
+    end
+
+    describe 'with a maximum length' do
+      subject { described_class.new(type_name, length:) }
+
+      describe 'with an inclusive range' do
+        sig { returns(T::Range[Integer]) }
+        def length
+          1..10
+        end
+
+        it 'returns the maximum length' do
+          assert_equal(10, subject.max_length)
+        end
+      end
+
+      describe 'with an exclusive range' do
+        sig { returns(T::Range[Integer]) }
+        def length
+          1...10
+        end
+
+        it 'returns the maximum length' do
+          assert_equal(9, subject.max_length)
+        end
+      end
+    end
+  end
+
+  describe '#==' do
+    include Support::TypeBehaviour::Equality
+  end
+
+  describe '#eql' do
+    include Support::TypeBehaviour::Eql
+  end
+
+  describe '#hash' do
+    include Support::TypeBehaviour::Hash
+  end
+
+  describe '#add_methods' do
+    include Support::TypeBehaviour::AddMethods
+  end
+
+  describe '#finalize' do
+    include Support::TypeBehaviour::Finalize
+  end
+end

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -1,0 +1,121 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Boa do
+  extend T::Sig
+
+  sig { returns(T::Class[Boa]) }
+  def described_class
+    Person
+  end
+
+  subject { described_class.new }
+
+  describe '.new' do
+    cover 'Boa#initialize'
+
+    describe 'with no attributes' do
+      it 'initializes the object' do
+        assert_kind_of(described_class, subject)
+      end
+
+      it 'does not set the name' do
+        assert_nil(subject.name)
+      end
+    end
+
+    describe 'with attributes' do
+      subject { described_class.new(name: 'Dan Kubb') }
+
+      it 'initializes the object' do
+        assert_kind_of(described_class, subject)
+      end
+
+      it 'sets the name' do
+        assert_equal('Dan Kubb', subject.name)
+      end
+    end
+
+    describe 'with unknown attributes' do
+      # provide attributes in reverse order to ensure that the error
+      # message sorts the attributes
+      subject { described_class.new(unknown_b: nil, unknown_a: nil) }
+
+      it 'raises an error' do
+        error = assert_raises(Boa::UnknownAttributeError) { subject }
+
+        assert_equal('Unknown attributes: unknown_a, unknown_b', error.message)
+      end
+    end
+  end
+
+  describe '#==' do
+    cover 'Boa::Equality#=='
+
+    describe 'when the objects have equivalent state' do
+      it 'returns true' do
+        assert_equal(subject, subject.dup)
+      end
+    end
+
+    describe 'when the objects have different state' do
+      it 'returns false' do
+        refute_equal(subject, described_class.new(name: 'Dan Kubb'))
+      end
+    end
+
+    describe 'when the objects have the same state, but one is a subclass' do
+      it 'returns true' do
+        subclass = Class.new(described_class)
+
+        assert_equal(subject, subclass.new)
+      end
+    end
+  end
+
+  describe 'eql?' do
+    cover 'Boa::Equality#eql?'
+
+    describe 'when the objects have equivalent state' do
+      it 'returns true' do
+        assert_operator(subject, :eql?, subject.dup)
+      end
+    end
+
+    describe 'when the objects have different state' do
+      it 'returns false' do
+        other = described_class.new(name: 'Dan Kubb')
+
+        refute_operator(subject, :eql?, other)
+      end
+    end
+
+    describe 'when the objects have the same state, but one is a subclass' do
+      it 'returns false' do
+        subclass = Class.new(described_class)
+
+        refute_operator(subject, :eql?, subclass.new)
+      end
+    end
+  end
+
+  describe '#hash' do
+    cover 'Boa::Equality#hash'
+
+    it 'returns an integer' do
+      assert_kind_of(Integer, subject.hash)
+    end
+
+    it 'returns the same value for equal objects' do
+      assert_equal(subject.hash, subject.dup.hash)
+    end
+
+    it 'returns a different values for different objects' do
+      other = described_class.new(name: 'Dan Kubb')
+
+      refute_equal(subject.hash, other.hash)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This branch adds the first set of base Boa objects, including a few types.

More types will be coming, but I wanted to set a baseline in order to establish shared specs for types.

### Dependencies

* [x] #1