### PR TITLE
Rename ClassMethods to ModelMethods

### DIFF
--- a/.mutant.yml
+++ b/.mutant.yml
@@ -12,7 +12,7 @@ matcher:
     - Boa*
   ignore:
     - Boa#model                     # T.unsafe is removed, but is required by sorbet
-    - Boa::ClassMethods#properties  # T.nilable is removed, but is required by sorbet
     - Boa::Equality#eql?            # T.nilable is removed, but is required by sorbet
+    - Boa::ModelMethods#properties  # T.nilable is removed, but is required by sorbet
     - Boa::Type#initialize          # T.nilable is removed, but is required by sorbet
     - Boa::Type::String#initialize  # T::Range[::Integer] is mutated to T::Range[Integer] which is wrong

--- a/lib/boa.rb
+++ b/lib/boa.rb
@@ -5,7 +5,7 @@ require 'ice_nine'
 require 'sorbet-runtime'
 
 require_relative 'boa/equality'
-require_relative 'boa/class_methods'
+require_relative 'boa/model_methods'
 require_relative 'boa/type'
 require_relative 'boa/type/object'
 require_relative 'boa/type/boolean'
@@ -36,7 +36,7 @@ module Boa
     end
   end
 
-  mixes_in_class_methods(ClassMethods)
+  mixes_in_class_methods(ModelMethods)
 
   abstract!
 
@@ -65,13 +65,13 @@ module Boa
 
   # The model of the object
   #
-  # @return [ClassMethods] the model of the object
+  # @return [ModelMethods] the model of the object
   #
   # @api private
-  sig { returns(ClassMethods) }
+  sig { returns(ModelMethods) }
   def model
     # self.class extends the class methods module
-    T.let(T.unsafe(self.class), ClassMethods) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUnsafe
+    T.let(T.unsafe(self.class), ModelMethods) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUnsafe
   end
 
   # Assert that the attributes are known

--- a/lib/boa/model_methods.rb
+++ b/lib/boa/model_methods.rb
@@ -7,7 +7,7 @@ module Boa
     extend T::Sig
     extend T::Helpers
 
-    requires_ancestor { Module }
+    requires_ancestor { Object }
 
     abstract!
 

--- a/lib/boa/model_methods.rb
+++ b/lib/boa/model_methods.rb
@@ -3,7 +3,7 @@
 
 module Boa
   # A module for class methods
-  module ClassMethods
+  module ModelMethods
     extend T::Sig
     extend T::Helpers
 
@@ -45,7 +45,7 @@ module Boa
     # @param name [Symbol] the name of the property
     # @param type [Type] the type of the property
     #
-    # @return [ClassMethods] the class method module
+    # @return [ModelMethods] the class method module
     #
     # @api public
     sig { params(name: Symbol, type: T::Class[Type], required: T::Boolean, options: Object).returns(T.self_type) }
@@ -60,7 +60,7 @@ module Boa
     #   klass = Class.new { include Boa }
     #   klass.finalize.frozen?             # => true
     #
-    # @return [ClassMethods] the class method module
+    # @return [ModelMethods] the class method module
     #
     # @api public
     sig { returns(T.self_type) }
@@ -79,7 +79,7 @@ module Boa
     #   klass.freeze
     #   klass.frozen? # => true
     #
-    # @return [ClassMethods] the class method module
+    # @return [ModelMethods] the class method module
     #
     # @api public
     sig { returns(T.self_type) }
@@ -90,7 +90,7 @@ module Boa
         T.let(instance_variable_get(ivar_name), Object).freeze
       end
 
-      T.let(super(), ClassMethods)
+      T.let(super(), ModelMethods)
     end
   end
 end

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -81,8 +81,6 @@ module Boa
     # @param includes [Object] the object to check inclusion against
     # @param ivar_name [Symbol] the name of the instance variable
     #
-    # @yield [] the block to instance_eval
-    #
     # @return [void]
     #
     # @api private

--- a/lib/boa/type/boolean.rb
+++ b/lib/boa/type/boolean.rb
@@ -33,7 +33,7 @@ module Boa
       #   type.add_methods(descendant)          # => type
       #   descendant.new.respond_to?(:author?)  # => true
       #
-      # @param descendant [ClassMethods] the class to add methods to
+      # @param descendant [ModelMethods] the class to add methods to
       #
       # @return [Type] the type
       #

--- a/lib/boa/type/boolean.rb
+++ b/lib/boa/type/boolean.rb
@@ -4,7 +4,7 @@
 module Boa
   class Type
     # A boolean type
-    class Boolean < Object
+    class Boolean < self
       # Initialize the boolean type
       #
       # @example

--- a/lib/boa/type/integer.rb
+++ b/lib/boa/type/integer.rb
@@ -4,7 +4,7 @@
 module Boa
   class Type
     # An integer type
-    class Integer < Object
+    class Integer < self
     end
   end
 end

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -4,7 +4,7 @@
 module Boa
   class Type
     # A string type
-    class String < Object
+    class String < self
       # The length of the string
       #
       # @example

--- a/test/unit/boa/model_methods_test.rb
+++ b/test/unit/boa/model_methods_test.rb
@@ -3,19 +3,19 @@
 
 require 'test_helper'
 
-describe Boa::ClassMethods do
+describe Boa::ModelMethods do
   extend T::Sig
 
   subject do
     Class.new do
-      extend Boa::ClassMethods
+      extend Boa::ModelMethods
 
       prop :name, Boa::Type::String
     end
   end
 
   describe '#inherited' do
-    cover 'Boa::ClassMethods#inherited'
+    cover 'Boa::ModelMethods#inherited'
 
     it 'copies the properties' do
       subclass = Class.new(subject)
@@ -38,7 +38,7 @@ describe Boa::ClassMethods do
   end
 
   describe '#properties' do
-    cover 'Boa::ClassMethods#properties'
+    cover 'Boa::ModelMethods#properties'
 
     it 'returns the properties' do
       assert_equal({ name: Boa::Type::String.new(:name) }, subject.properties)
@@ -46,7 +46,7 @@ describe Boa::ClassMethods do
   end
 
   describe '#prop' do
-    cover 'Boa::ClassMethods#prop'
+    cover 'Boa::ModelMethods#prop'
 
     sig { returns(T::Hash[Symbol, Object]) }
     def options
@@ -65,7 +65,7 @@ describe Boa::ClassMethods do
   end
 
   describe '#finalize' do
-    cover 'Boa::ClassMethods#finalize'
+    cover 'Boa::ModelMethods#finalize'
 
     it 'adds the methods to the class' do
       refute_respond_to(subject.new, :name)
@@ -104,7 +104,7 @@ describe Boa::ClassMethods do
   end
 
   describe '#freeze' do
-    cover 'Boa::ClassMethods#freeze'
+    cover 'Boa::ModelMethods#freeze'
 
     before do
       subject.class_eval { @ivar = +'value' }


### PR DESCRIPTION
### Summary

- Remove Type#initialize yard docs
- Rename ClassMethods to ModelMethods
- Change Type subclasses to inherit directly
- Change ModelMethods to require Object be the ancestor
