### PR TITLE
Add shared test support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ Metrics/MethodLength:
     - spec/doctest_helper.rb
     - test/support/**/*.rb
 
+Metrics/ModuleLength:
+  Exclude:
+    - test/support/**/*.rb
+
 Naming/BlockForwarding:
   EnforcedStyle: explicit
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,9 @@ Security/CompoundHash:
 Sorbet/ForbidTStruct:
   Enabled: false
 
+Sorbet/ForbidTypeAliasedShapes:
+  Enabled: false
+
 Sorbet/RedundantExtendTSig:
   Enabled: false
 
@@ -107,12 +110,16 @@ Style/MethodCallWithArgsParentheses:
     - describe
     - extend
     - include
+    - include_context
+    - include_examples
     - it
     - prop
     - protected
     - public_constant
     - require
     - require_relative
+    - shared_context
+    - shared_examples
   EnforcedStyle: require_parentheses
   Exclude:
     - .simplecov

--- a/test/support/shared_setup.rb
+++ b/test/support/shared_setup.rb
@@ -1,0 +1,52 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Support
+  module SharedSetup
+    extend T::Helpers
+    extend T::Sig
+
+    requires_ancestor { T.class_of(Minitest::Spec) }
+
+    Metadata = T.type_alias { T.any(T::Hash[Symbol, Object], T::Array[Object]) }
+    Example  = T.type_alias { T.proc.params(arg0: T.nilable(Metadata)).void    }
+
+    sig { params(name: String, example: Example).void }
+    def shared_examples(name, &example)
+      raise(ArgumentError, "Shared context/example #{name.inspect} already exists") if examples.key?(name)
+
+      examples[name] = example
+    end
+    alias shared_context shared_examples
+
+    sig { params(name: String, metadata: Metadata).void }
+    def include_examples(name, metadata = {})
+      example =
+        examples.fetch(name) do
+          raise(ArgumentError, "Unknown shared context/example named #{name.inspect}")
+        end
+
+      class_exec(metadata, &example)
+    end
+    alias include_context include_examples
+
+  private
+
+    sig { returns(T::Hash[String, Example]) }
+    def examples
+      @examples ||= T.let({}, T.nilable(T::Hash[String, Example]))
+    end
+
+    sig { params(descendant: T.class_of(Minitest::Spec)).void }
+    def inherited(descendant)
+      descendant.instance_variable_set(:@examples, examples.dup)
+      super
+    end
+
+    sig { params(descendant: T.class_of(Minitest::Spec)).void }
+    def included(descendant)
+      descendant.instance_variable_set(:@examples, examples.dup)
+      super
+    end
+  end
+end

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -196,6 +196,16 @@ module Support
       end
     end
 
+    shared_examples 'Boa::Type#includes' do
+      cover 'Boa::Type#incldues'
+
+      subject { described_class.new(type_name, includes:) }
+
+      it 'returns the includes' do
+        assert_same(includes, subject.includes)
+      end
+    end
+
     shared_examples 'Boa::Type#==' do
       cover 'Boa::Equality#=='
 

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -221,6 +221,29 @@ module Support
       end
     end
 
+    shared_examples 'Boa::Type#default' do
+      cover 'Boa::Type#default'
+
+      subject { described_class.new(type_name, **options) }
+
+      describe 'with a default option' do
+        sig { returns(T::Hash[Symbol, Object]) }
+        def options
+          { default: }
+        end
+
+        it 'returns the default' do
+          assert_same(default, subject.default)
+        end
+      end
+
+      describe 'with no default option' do
+        it 'returns nil' do
+          assert_nil(subject.default)
+        end
+      end
+    end
+
     shared_examples 'Boa::Type#==' do
       cover 'Boa::Equality#=='
 

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -3,206 +3,181 @@
 
 module Support
   module TypeBehaviour
-    module New
-      extend T::Sig
+    extend SharedSetup
 
-      sig { params(descendant: T.class_of(Minitest::Spec)).void }
-      def self.included(descendant)
-        descendant.class_eval do
-          cover 'Boa::Type#initialize'
+    shared_examples 'Boa::Type.new' do
+      cover 'Boa::Type.new'
+      cover 'Boa::Type#initialize'
 
-          it 'sets the name attribute' do
-            assert_equal(type_name, subject.name)
+      it 'sets the name attribute' do
+        assert_equal(type_name, subject.name)
+      end
+
+      describe 'with no default option' do
+        it 'sets the default attribute to the default' do
+          assert_nil(subject.default)
+        end
+      end
+
+      describe 'with a default option' do
+        subject { described_class.new(type_name, default: non_nil_default) }
+
+        describe 'with a non-nil value' do
+          it 'sets the default attribute' do
+            assert_equal(non_nil_default, subject.default)
           end
+        end
+      end
 
-          describe 'with no default option' do
-            it 'sets the default attribute to the default' do
-              assert_nil(subject.default)
-            end
+      describe 'with no includes option' do
+        it 'sets the includes attribute to the default' do
+          if default_includes.nil?
+            assert_nil(subject.includes)
+          else
+            assert_equal(default_includes, subject.includes)
           end
+        end
+      end
 
-          describe 'with a default option' do
-            subject { described_class.new(type_name, default: non_nil_default) }
+      describe 'with an includes option' do
+        subject { described_class.new(type_name, includes: []) }
 
-            describe 'with a non-nil value' do
-              it 'sets the default attribute' do
-                assert_equal(non_nil_default, subject.default)
-              end
-            end
-          end
-
-          describe 'with no includes option' do
-            it 'sets the includes attribute to the default' do
-              if default_includes.nil?
-                assert_nil(subject.includes)
-              else
-                assert_equal(default_includes, subject.includes)
-              end
-            end
-          end
-
-          describe 'with an includes option' do
-            subject { described_class.new(type_name, includes: []) }
-
-            it 'sets the includes attribute to an empty list' do
-              assert_empty(subject.includes)
-            end
-          end
+        it 'sets the includes attribute to an empty list' do
+          assert_empty(subject.includes)
         end
       end
     end
 
-    module Equality
-      extend T::Sig
+    shared_examples 'Boa::Type#==' do
+      cover 'Boa::Equality#=='
 
-      sig { params(descendant: T.class_of(Minitest::Spec)).void }
-      def self.included(descendant)
-        descendant.class_eval do
-          cover 'Boa::Equality#=='
+      describe 'when the types have the same name and options' do
+        it 'returns true' do
+          assert_equal(subject, other)
+        end
+      end
 
-          describe 'when the types have the same name and options' do
-            it 'returns true' do
-              assert_equal(subject, other)
-            end
-          end
+      describe 'when the types have different names and same options' do
+        sig { returns(Symbol) }
+        def other_name
+          :other
+        end
 
-          describe 'when the types have different names and same options' do
-            sig { returns(Symbol) }
-            def other_name
-              :other
-            end
+        it 'returns false' do
+          refute_equal(subject, other)
+        end
+      end
 
-            it 'returns false' do
-              refute_equal(subject, other)
-            end
-          end
+      describe 'when the types have the same name and options, but one is subclass' do
+        sig { returns(T.class_of(Boa::Type)) }
+        def other_class
+          Class.new(described_class)
+        end
 
-          describe 'when the types have the same name and options, but one is subclass' do
-            sig { returns(T.class_of(Boa::Type)) }
-            def other_class
-              Class.new(described_class)
-            end
+        it 'returns true' do
+          assert_equal(subject, other)
+        end
+      end
 
-            it 'returns true' do
-              assert_equal(subject, other)
-            end
-          end
+      describe 'when the types have the same name and options, but one is not a subclass' do
+        sig { returns(T.class_of(Boa::Type)) }
+        def other_class
+          Class.new(Boa::Type)
+        end
 
-          describe 'when the types have the same name and options, but one is not a subclass' do
-            sig { returns(T.class_of(Boa::Type)) }
-            def other_class
-              Class.new(Boa::Type)
-            end
+        it 'returns true' do
+          refute_equal(subject, other)
+        end
+      end
 
-            it 'returns true' do
-              refute_equal(subject, other)
-            end
-          end
+      describe 'when the types have the same name and different options' do
+        sig { returns(T::Hash[Symbol, Object]) }
+        def other_options
+          different_options
+        end
 
-          describe 'when the types have the same name and different options' do
-            sig { returns(T::Hash[Symbol, Object]) }
-            def other_options
-              different_options
-            end
-
-            it 'returns false' do
-              refute_equal(subject, other)
-            end
-          end
+        it 'returns false' do
+          refute_equal(subject, other)
         end
       end
     end
 
-    module Eql
-      extend T::Sig
+    shared_examples 'Boa::Type#eql?' do
+      cover 'Boa::Equality#eql?'
 
-      sig { params(descendant: T.class_of(Minitest::Spec)).void }
-      def self.included(descendant)
-        descendant.class_eval do
-          cover 'Boa::Equality#eql?'
+      describe 'when the types have the same name and options' do
+        it 'returns true' do
+          assert_operator(subject, :eql?, other)
+        end
+      end
 
-          describe 'when the types have the same name and options' do
-            it 'returns true' do
-              assert_operator(subject, :eql?, other)
-            end
-          end
+      describe 'when the types have different names and same options' do
+        sig { returns(Symbol) }
+        def other_name
+          :other
+        end
 
-          describe 'when the types have different names and same options' do
-            sig { returns(Symbol) }
-            def other_name
-              :other
-            end
+        it 'returns false' do
+          refute_operator(subject, :eql?, other)
+        end
+      end
 
-            it 'returns false' do
-              refute_operator(subject, :eql?, other)
-            end
-          end
+      describe 'when the types have the same name and options, but one is subclass' do
+        sig { returns(T.class_of(Boa::Type)) }
+        def other_class
+          Class.new(described_class)
+        end
 
-          describe 'when the types have the same name and options, but one is subclass' do
-            sig { returns(T.class_of(Boa::Type)) }
-            def other_class
-              Class.new(described_class)
-            end
+        it 'returns false' do
+          refute_operator(subject, :eql?, other)
+        end
+      end
 
-            it 'returns false' do
-              refute_operator(subject, :eql?, other)
-            end
-          end
+      describe 'when the types have the same name and options, but one is not a subclass' do
+        sig { returns(T.class_of(Boa::Type)) }
+        def other_class
+          Class.new(Boa::Type)
+        end
 
-          describe 'when the types have the same name and options, but one is not a subclass' do
-            sig { returns(T.class_of(Boa::Type)) }
-            def other_class
-              Class.new(Boa::Type)
-            end
+        it 'returns true' do
+          refute_operator(subject, :eql?, other)
+        end
+      end
 
-            it 'returns true' do
-              refute_operator(subject, :eql?, other)
-            end
-          end
+      describe 'when the types have the same name and different options' do
+        sig { returns(T::Hash[Symbol, Object]) }
+        def other_options
+          different_options
+        end
 
-          describe 'when the types have the same name and different options' do
-            sig { returns(T::Hash[Symbol, Object]) }
-            def other_options
-              different_options
-            end
-
-            it 'returns false' do
-              refute_operator(subject, :eql?, other)
-            end
-          end
+        it 'returns false' do
+          refute_operator(subject, :eql?, other)
         end
       end
     end
 
-    module Hash
-      extend T::Sig
+    shared_examples 'Boa::Type#hash' do
+      cover 'Boa::Equality#hash'
 
-      sig { params(descendant: T.class_of(Minitest::Spec)).void }
-      def self.included(descendant)
-        descendant.class_eval do
-          cover 'Boa::Equality#hash'
+      it 'returns an integer' do
+        assert_kind_of(Integer, subject.hash)
+      end
 
-          it 'returns an integer' do
-            assert_kind_of(Integer, subject.hash)
-          end
+      it 'returns the same value for equal objects' do
+        assert_equal(subject.hash, other.hash)
+      end
 
-          it 'returns the same value for equal objects' do
-            assert_equal(subject.hash, other.hash)
-          end
+      it 'returns the different values for different objects' do
+        other = described_class.new(other_name, **different_options)
 
-          it 'returns the different values for different objects' do
-            other = described_class.new(other_name, **different_options)
+        refute_equal(subject.hash, other.hash)
+      end
 
-            refute_equal(subject.hash, other.hash)
-          end
+      it 'returns different values for objects with the same name and options, but one is subclass' do
+        subclass = Class.new(described_class)
+        other    = subclass.new(type_name, **options)
 
-          it 'returns different values for objects with the same name and options, but one is subclass' do
-            subclass = Class.new(described_class)
-            other    = subclass.new(type_name, **options)
-
-            refute_equal(subject.hash, other.hash)
-          end
-        end
+        refute_equal(subject.hash, other.hash)
       end
     end
   end

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -188,6 +188,14 @@ module Support
       end
     end
 
+    shared_examples 'Boa::Type#name' do
+      cover 'Boa::Type#name'
+
+      it 'returns the name' do
+        assert_same(type_name, subject.name)
+      end
+    end
+
     shared_examples 'Boa::Type#==' do
       cover 'Boa::Equality#=='
 

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -3,7 +3,147 @@
 
 module Support
   module TypeBehaviour
+    extend T::Sig
     extend SharedSetup
+
+    sig { returns(T.class_of(Boa::Type)) }
+    def type_class
+      @type_class ||= Class.new(described_class)
+    end
+
+    sig { returns(Module) }
+    def class_type
+      @class_type ||= Class.new
+    end
+
+    sig do
+      params(klass: T.class_of(Object), method_name: Symbol, block: T.proc.params(descendant: T.class_of(Boa::Type)).void).void
+    end
+    def replace_method(klass, method_name, &block)
+      original_verbose = $VERBOSE
+      $VERBOSE         = nil
+
+      # Replace the singleton method without warnings
+      klass.define_singleton_method(method_name, &block)
+
+      $VERBOSE = original_verbose
+    end
+
+    shared_examples 'Boa::Type.[]' do
+      cover 'Boa::Type.[]'
+
+      subject { described_class[class_type] }
+
+      describe 'when class type is registered' do
+        sig { returns(Module) }
+        def class_type
+          String
+        end
+
+        it 'returns the expected type class' do
+          assert_same(Boa::Type::String, subject)
+        end
+      end
+
+      describe 'when class type is not registered' do
+        it 'returns the default type class' do
+          # assert there is no explict mapping for the class type
+          error =
+            assert_raises(ArgumentError) do
+              described_class[class_type]
+            end
+
+          assert_equal("type class for #{class_type} is unknown", error.message)
+        end
+      end
+    end
+
+    shared_examples 'Boa::Type.[]=' do
+      cover 'Boa::Type.[]='
+
+      subject { described_class[class_type] = type_class }
+
+      after do
+        # Remove the type class from the registry
+        described_class.send(:class_types).delete(class_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
+      end
+
+      it 'sets the class type' do
+        # assert there is no explict mapping for the class type
+        assert_raises(ArgumentError) do
+          described_class[class_type]
+        end
+
+        subject
+
+        assert_same(type_class, described_class[class_type])
+      end
+    end
+
+    shared_examples 'Boa::Type.class_type' do
+      cover 'Boa::Type.class_type'
+
+      subject { described_class.class_type(class_type) }
+
+      after do
+        # Remove the type class from the registry
+        described_class.send(:class_types).delete(class_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
+      end
+
+      it 'returns the type class' do
+        assert_same(described_class, subject)
+      end
+
+      it 'sets the class type' do
+        # assert there is no explict mapping for the class type
+        assert_raises(ArgumentError) do
+          described_class[class_type]
+        end
+
+        subject
+
+        assert_same(described_class, described_class[class_type])
+      end
+    end
+
+    shared_examples 'Boa::Type.inherited' do
+      cover 'Boa::Type.inherited'
+
+      subject { Class.new(described_class) }
+
+      it 'set the class types' do
+        assert_same(described_class.send(:class_types), subject.send(:class_types)) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
+      end
+
+      it 'calls super' do
+        described_class    = self.described_class
+        object_inherited   = Object.method(:inherited)
+        original_inherited = described_class.method(:inherited)
+        inherited          = []
+
+        # Override described_class.inherited
+        replace_method(described_class, :inherited) do |descendant|
+          inherited << described_class
+          original_inherited.call(descendant)
+        end
+
+        # Override Object.inherited
+        replace_method(Object, :inherited) do |descendant|
+          inherited << Object
+          object_inherited.call(descendant)
+        end
+
+        subject
+
+        assert_equal([described_class, Object], inherited)
+
+        # Restore Object.inherited
+        replace_method(Object, :inherited, &object_inherited)
+
+        # Restore described_class.inherited
+        replace_method(described_class, :inherited, &original_inherited)
+      end
+    end
 
     shared_examples 'Boa::Type.new' do
       cover 'Boa::Type.new'

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -206,6 +206,21 @@ module Support
       end
     end
 
+    shared_examples 'Boa::Type#options' do
+      cover 'Boa::Type#options'
+
+      subject { described_class.new(type_name, **options) }
+
+      sig { returns(T::Hash[Symbol, Object]) }
+      def options
+        { default: nil }
+      end
+
+      it 'returns the options' do
+        assert_equal(options, subject.options)
+      end
+    end
+
     shared_examples 'Boa::Type#==' do
       cover 'Boa::Equality#=='
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,12 @@ require 'minitest/autorun'
 require 'mutant/minitest/coverage'
 require 'sorbet-runtime'
 
+require_relative 'support/shared_setup'
 require_relative 'support/type_behaviour'
 
 require 'boa'
+
+Minitest::Spec.extend(Support::SharedSetup)
 
 class Person < T::Struct
   include Boa

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 
 describe Boa::Type::Boolean do
   extend T::Sig
+  include Support::TypeBehaviour
 
   subject { described_class.new(type_name, **options) }
 
@@ -37,7 +38,7 @@ describe Boa::Type::Boolean do
   end
 
   describe '.new' do
-    include Support::TypeBehaviour::New
+    include_examples 'Boa::Type.new'
 
     cover 'Boa::Type::Boolean#initialize'
 
@@ -53,14 +54,14 @@ describe Boa::Type::Boolean do
   end
 
   describe '#==' do
-    include Support::TypeBehaviour::Equality
+    include_examples 'Boa::Type#=='
   end
 
-  describe '#eql' do
-    include Support::TypeBehaviour::Eql
+  describe '#eql?' do
+    include_examples 'Boa::Type#eql?'
   end
 
   describe '#hash' do
-    include Support::TypeBehaviour::Hash
+    include_examples 'Boa::Type#hash'
   end
 end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -69,6 +69,10 @@ describe Boa::Type::Boolean do
     end
   end
 
+  describe '#name' do
+    include_examples 'Boa::Type#name'
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
   end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -82,6 +82,10 @@ describe Boa::Type::Boolean do
     end
   end
 
+  describe '#options' do
+    include_examples 'Boa::Type#options'
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
   end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -37,6 +37,22 @@ describe Boa::Type::Boolean do
     { default: false }
   end
 
+  describe '.[]' do
+    include_examples 'Boa::Type.[]'
+  end
+
+  describe '.[]=' do
+    include_examples 'Boa::Type.[]='
+  end
+
+  describe '.class_type' do
+    include_examples 'Boa::Type.class_type'
+  end
+
+  describe '.inherited' do
+    include_examples 'Boa::Type.inherited'
+  end
+
   describe '.new' do
     include_examples 'Boa::Type.new'
 

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -73,6 +73,15 @@ describe Boa::Type::Boolean do
     include_examples 'Boa::Type#name'
   end
 
+  describe '#includes' do
+    include_examples 'Boa::Type#includes'
+
+    sig { returns(Object) }
+    def includes
+      @includes ||= [true]
+    end
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
   end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -86,6 +86,15 @@ describe Boa::Type::Boolean do
     include_examples 'Boa::Type#options'
   end
 
+  describe '#default' do
+    include_examples 'Boa::Type#default'
+
+    sig { returns(Object) }
+    def default
+      false
+    end
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
   end

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -126,6 +126,15 @@ describe Boa::Type::Integer do
     include_examples 'Boa::Type#options'
   end
 
+  describe '#default' do
+    include_examples 'Boa::Type#default'
+
+    sig { returns(Object) }
+    def default
+      1
+    end
+  end
+
   describe '#min_range' do
     cover 'Boa::Type::Integer#min_range'
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -109,6 +109,10 @@ describe Boa::Type::Integer do
     end
   end
 
+  describe '#name' do
+    include_examples 'Boa::Type#name'
+  end
+
   describe '#min_range' do
     cover 'Boa::Type::Integer#min_range'
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -37,6 +37,22 @@ describe Boa::Type::Integer do
     { default: 42 }
   end
 
+  describe '.[]' do
+    include_examples 'Boa::Type.[]'
+  end
+
+  describe '.[]=' do
+    include_examples 'Boa::Type.[]='
+  end
+
+  describe '.class_type' do
+    include_examples 'Boa::Type.class_type'
+  end
+
+  describe '.inherited' do
+    include_examples 'Boa::Type.inherited'
+  end
+
   describe '.new' do
     include_examples 'Boa::Type.new'
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -122,6 +122,10 @@ describe Boa::Type::Integer do
     end
   end
 
+  describe '#options' do
+    include_examples 'Boa::Type#options'
+  end
+
   describe '#min_range' do
     cover 'Boa::Type::Integer#min_range'
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -113,6 +113,15 @@ describe Boa::Type::Integer do
     include_examples 'Boa::Type#name'
   end
 
+  describe '#includes' do
+    include_examples 'Boa::Type#includes'
+
+    sig { returns(Object) }
+    def includes
+      @includes ||= [1]
+    end
+  end
+
   describe '#min_range' do
     cover 'Boa::Type::Integer#min_range'
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 
 describe Boa::Type::Integer do
   extend T::Sig
+  include Support::TypeBehaviour
 
   subject { described_class.new(type_name, **options) }
 
@@ -37,7 +38,7 @@ describe Boa::Type::Integer do
   end
 
   describe '.new' do
-    include Support::TypeBehaviour::New
+    include_examples 'Boa::Type.new'
 
     cover 'Boa::Type::Integer#initialize'
 
@@ -149,14 +150,14 @@ describe Boa::Type::Integer do
   end
 
   describe '#==' do
-    include Support::TypeBehaviour::Equality
+    include_examples 'Boa::Type#=='
   end
 
   describe '#eql?' do
-    include Support::TypeBehaviour::Eql
+    include_examples 'Boa::Type#eql?'
   end
 
   describe '#hash' do
-    include Support::TypeBehaviour::Hash
+    include_examples 'Boa::Type#hash'
   end
 end

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -69,6 +69,10 @@ describe Boa::Type::Object do
     end
   end
 
+  describe '#name' do
+    include_examples 'Boa::Type#name'
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 
 describe Boa::Type::Object do
   extend T::Sig
+  include Support::TypeBehaviour
 
   subject { described_class.new(type_name) }
 
@@ -37,7 +38,7 @@ describe Boa::Type::Object do
   end
 
   describe '.new' do
-    include Support::TypeBehaviour::New
+    include_examples 'Boa::Type.new'
 
     cover 'Boa::Type::Object#initiaize'
 
@@ -53,7 +54,7 @@ describe Boa::Type::Object do
   end
 
   describe '#==' do
-    include Support::TypeBehaviour::Equality
+    include_examples 'Boa::Type#=='
 
     it 'is false when object state is equal but does not eql?' do
       subject = described_class.new(type_name, default: 1)
@@ -65,10 +66,10 @@ describe Boa::Type::Object do
   end
 
   describe '#eql' do
-    include Support::TypeBehaviour::Eql
+    include_examples 'Boa::Type#eql?'
   end
 
   describe '#hash' do
-    include Support::TypeBehaviour::Hash
+    include_examples 'Boa::Type#hash'
   end
 end

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -37,6 +37,22 @@ describe Boa::Type::Object do
     { default: Object.new }
   end
 
+  describe '.[]' do
+    include_examples 'Boa::Type.[]'
+  end
+
+  describe '.[]=' do
+    include_examples 'Boa::Type.[]='
+  end
+
+  describe '.class_type' do
+    include_examples 'Boa::Type.class_type'
+  end
+
+  describe '.inherited' do
+    include_examples 'Boa::Type.inherited'
+  end
+
   describe '.new' do
     include_examples 'Boa::Type.new'
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -73,6 +73,15 @@ describe Boa::Type::Object do
     include_examples 'Boa::Type#name'
   end
 
+  describe '#includes' do
+    include_examples 'Boa::Type#includes'
+
+    sig { returns(Object) }
+    def includes
+      @includes ||= [Object.new]
+    end
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -82,6 +82,10 @@ describe Boa::Type::Object do
     end
   end
 
+  describe '#options' do
+    include_examples 'Boa::Type#options'
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -86,6 +86,15 @@ describe Boa::Type::Object do
     include_examples 'Boa::Type#options'
   end
 
+  describe '#default' do
+    include_examples 'Boa::Type#default'
+
+    sig { returns(Object) }
+    def default
+      @default ||= Object.new
+    end
+  end
+
   describe '#==' do
     include_examples 'Boa::Type#=='
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -135,6 +135,15 @@ describe Boa::Type::String do
     include_examples 'Boa::Type#name'
   end
 
+  describe '#includes' do
+    include_examples 'Boa::Type#includes'
+
+    sig { returns(Object) }
+    def includes
+      @includes ||= %w[test]
+    end
+  end
+
   describe '#min_length' do
     cover 'Boa::Type::String#min_length'
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -144,6 +144,10 @@ describe Boa::Type::String do
     end
   end
 
+  describe '#options' do
+    include_examples 'Boa::Type#options'
+  end
+
   describe '#min_length' do
     cover 'Boa::Type::String#min_length'
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -131,6 +131,10 @@ describe Boa::Type::String do
     end
   end
 
+  describe '#name' do
+    include_examples 'Boa::Type#name'
+  end
+
   describe '#min_length' do
     cover 'Boa::Type::String#min_length'
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -37,6 +37,22 @@ describe Boa::Type::String do
     { default: 'Other Name' }
   end
 
+  describe '.[]' do
+    include_examples 'Boa::Type.[]'
+  end
+
+  describe '.[]=' do
+    include_examples 'Boa::Type.[]='
+  end
+
+  describe '.class_type' do
+    include_examples 'Boa::Type.class_type'
+  end
+
+  describe '.inherited' do
+    include_examples 'Boa::Type.inherited'
+  end
+
   describe '.new' do
     include_examples 'Boa::Type.new'
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -148,6 +148,15 @@ describe Boa::Type::String do
     include_examples 'Boa::Type#options'
   end
 
+  describe '#default' do
+    include_examples 'Boa::Type#default'
+
+    sig { returns(Object) }
+    def default
+      'test'
+    end
+  end
+
   describe '#min_length' do
     cover 'Boa::Type::String#min_length'
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 
 describe Boa::Type::String do
   extend T::Sig
+  include Support::TypeBehaviour
 
   subject { described_class.new(type_name, **options) }
 
@@ -37,7 +38,7 @@ describe Boa::Type::String do
   end
 
   describe '.new' do
-    include Support::TypeBehaviour::New
+    include_examples 'Boa::Type.new'
 
     cover 'Boa::Type::String#initialize'
 
@@ -174,14 +175,14 @@ describe Boa::Type::String do
   end
 
   describe '#==' do
-    include Support::TypeBehaviour::Equality
+    include_examples 'Boa::Type#=='
   end
 
-  describe '#eql' do
-    include Support::TypeBehaviour::Eql
+  describe '#eql?' do
+    include_examples 'Boa::Type#eql?'
   end
 
   describe '#hash' do
-    include Support::TypeBehaviour::Hash
+    include_examples 'Boa::Type#hash'
   end
 end

--- a/test/unit/boa/type_test.rb
+++ b/test/unit/boa/type_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 
 describe Boa::Type do
   extend T::Sig
+  include Support::TypeBehaviour
 
   sig { returns(T.class_of(Boa::Type)) }
   def described_class
@@ -12,151 +13,18 @@ describe Boa::Type do
   end
 
   describe '.[]' do
-    cover 'Boa::Type.[]'
-
-    subject { described_class[class_type] }
-
-    describe 'when class type is registered' do
-      sig { returns(Module) }
-      def class_type
-        String
-      end
-
-      it 'returns the expected type class' do
-        assert_same(Boa::Type::String, subject)
-      end
-    end
-
-    describe 'when class type is not registered' do
-      sig { returns(Module) }
-      def class_type
-        @class_type ||= Class.new
-      end
-
-      it 'returns the default type class' do
-        # assert there is no explict mapping for the class type
-        error =
-          assert_raises(ArgumentError) do
-            described_class[class_type]
-          end
-
-        assert_equal("type class for #{class_type} is unknown", error.message)
-      end
-    end
+    include_examples 'Boa::Type.[]'
   end
 
   describe '.[]=' do
-    cover 'Boa::Type.[]='
-
-    subject { described_class[class_type] = type_class }
-
-    sig { returns(Module) }
-    def class_type
-      @class_type ||= Class.new
-    end
-
-    sig { returns(T.class_of(Boa::Type)) }
-    def type_class
-      @type_class ||= Class.new(described_class)
-    end
-
-    after do
-      # Remove the type class from the registry
-      described_class.send(:class_types).delete(class_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
-    end
-
-    it 'sets the class type' do
-      # assert there is no explict mapping for the class type
-      assert_raises(ArgumentError) do
-        described_class[class_type]
-      end
-
-      subject
-
-      assert_same(type_class, described_class[class_type])
-    end
+    include_examples 'Boa::Type.[]='
   end
 
   describe '.class_type' do
-    cover 'Boa::Type.class_type'
-
-    subject { described_class.class_type(class_type) }
-
-    sig { returns(Module) }
-    def class_type
-      @class_type ||= Class.new
-    end
-
-    after do
-      # Remove the type class from the registry
-      described_class.send(:class_types).delete(class_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
-    end
-
-    it 'returns the type class' do
-      assert_same(described_class, subject)
-    end
-
-    it 'sets the class type' do
-      # assert there is no explict mapping for the class type
-      assert_raises(ArgumentError) do
-        described_class[class_type]
-      end
-
-      subject
-
-      assert_same(described_class, described_class[class_type])
-    end
+    include_examples 'Boa::Type.class_type'
   end
 
   describe '.inherited' do
-    cover 'Boa::Type.inherited'
-
-    subject { Class.new(described_class) }
-
-    sig do
-      params(klass: T.class_of(Object), method_name: Symbol, block: T.proc.params(descendant: T.class_of(Boa::Type)).void).void
-    end
-    def replace_method(klass, method_name, &block)
-      original_verbose = $VERBOSE
-      $VERBOSE         = nil
-
-      # Replace the singleton method without warnings
-      klass.define_singleton_method(method_name, &block)
-
-      $VERBOSE = original_verbose
-    end
-
-    it 'set the class types' do
-      assert_same(described_class.send(:class_types), subject.send(:class_types)) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
-    end
-
-    it 'calls super' do
-      superclass           = Boa::Type.superclass
-      superclass_inherited = superclass.method(:inherited)
-      original_inherited   = Boa::Type.method(:inherited)
-      inherited            = []
-
-      # Override Boa::Type.inherited
-      replace_method(Boa::Type, :inherited) do |descendant|
-        inherited << Boa::Type
-        original_inherited.call(descendant)
-      end
-
-      # Override superclass.inherited
-      replace_method(superclass, :inherited) do |descendant|
-        inherited << superclass
-        superclass_inherited.call(descendant)
-      end
-
-      subject
-
-      assert_equal([Boa::Type, superclass], inherited)
-
-      # Restore superclass.inherited
-      replace_method(superclass, :inherited, &superclass_inherited)
-
-      # Restore Boa::Type.inherited
-      replace_method(Boa::Type, :inherited, &original_inherited)
-    end
+    include_examples 'Boa::Type.inherited'
   end
 end


### PR DESCRIPTION
### Summary

- [x] [Add Support::SharedSetup](https://github.com/dkubb/boa/pull/64/commits/84df759830707657fa3a0e9fd1bd55def81c21a4)
- [x] [Change Support::TypeBehaviour to use SharedSetup](https://github.com/dkubb/boa/pull/64/commits/fc61c85a078c7dd0034712133169b24174b241ee)
- [x] [Change Boa::Type class method tests to be in Support::TypeBehaviour](https://github.com/dkubb/boa/pull/64/commits/c04b7350effd00da0a083af568b8dd5243a8cd1b)
- [x] [Add Type subclass tests for class methods](https://github.com/dkubb/boa/pull/64/commits/a9fd4fbfdd3f1c4116ed087f81a055df586e5bcf)
- [x] [Add Boa::Type#name shared test](https://github.com/dkubb/boa/pull/64/commits/86f8a5d74acd0d8ad9c965edf0ffdbd2d688a812)
- [x] [Add Boa::Type#includes shared test](https://github.com/dkubb/boa/pull/64/commits/b192b3a00d6004e08825ca58b50473ecdae01f2a)
- [x] [Add Boa::Type#options shared test](https://github.com/dkubb/boa/pull/64/commits/f4171512892efc743fa04cc02e52d6a1b4ed4d03)
- [x] [Add Boa::Type#default shared test](https://github.com/dkubb/boa/pull/64/commits/33ccc329f4e9ac517662ce42d7b7567155be8078)
