### PR TITLE
Change Type intefaces to be more consistent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,9 @@ Style/ArgumentsForwarding:
 Style/Attr:
   Enabled: false
 
+Style/ConstantVisibility:
+  Enabled: false
+
 Style/Copyright:
   Enabled: false
 

--- a/lib/boa/class_methods.rb
+++ b/lib/boa/class_methods.rb
@@ -29,16 +29,16 @@ module Boa
     #   klass.equal?(result)                    # => true
     #
     # @param name [Symbol] the name of the property
-    # @param base_type [Type::Base] the type of the property
+    # @param class_type [Type::ClassType] the type of the property
     # @param options [Hash] the options for the property
     #
     # @return [ClassMethods] the class method module
     #
     # @api public
-    sig { params(name: Symbol, base_type: Type::Base, options: Object).returns(T.self_type) }
-    def prop(name, base_type, **options)
-      property = properties[name] = Type[base_type].new(name, **options)
-      super(name, base_type, **property.options)
+    sig { params(name: Symbol, class_type: Type::ClassType, options: Object).returns(T.self_type) }
+    def prop(name, class_type, **options)
+      property = properties[name] = Type[class_type].new(name, **options)
+      super(name, class_type, **property.options)
       self
     end
 

--- a/lib/boa/class_methods.rb
+++ b/lib/boa/class_methods.rb
@@ -29,7 +29,7 @@ module Boa
     #   klass.equal?(result)                    # => true
     #
     # @param name [Symbol] the name of the property
-    # @param base_type [Class] the type of the property
+    # @param base_type [Type::Base] the type of the property
     # @param options [Hash] the options for the property
     #
     # @return [ClassMethods] the class method module

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -24,7 +24,7 @@ module Boa
     # @return [Class<Type>] the type for the base type
     #
     # @api public
-    sig { params(base_type: Base).returns(T.class_of(Type)) }
+    sig { overridable.params(base_type: Base).returns(T.class_of(Type)) }
     def self.[](base_type)
       base_types.fetch(base_type, Object)
     end
@@ -41,7 +41,7 @@ module Boa
     # @return [Class<Type>] the type for the base type
     #
     # @api public
-    sig { params(base_type: Base, descendant: T.class_of(Type)).returns(T.class_of(Type)) }
+    sig { overridable.params(base_type: Base, descendant: T.class_of(Type)).returns(T.class_of(Type)) }
     def self.[]=(base_type, descendant)
       base_types[base_type] = descendant
     end
@@ -51,7 +51,7 @@ module Boa
     # @return [Hash{Base => Class<Type>}] the base types
     #
     # @api private
-    sig { returns(T::Hash[Base, T.class_of(Type)]) }
+    sig { overridable.returns(T::Hash[Base, T.class_of(Type)]) }
     def self.base_types
       @base_types ||= T.let({}, T.nilable(T::Hash[Base, T.class_of(Type)]))
     end

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -15,8 +15,12 @@ module Boa
 
     # Lookup the type for a class type
     #
-    # @example
+    # @example when type class type is registered
     #   Boa::Type[::String]  # => Boa::Type::String
+    #
+    # @example when type class type is unknown
+    #   OtherClass = Class.new
+    #   Boa::Type[OtherClass] # => raise ArgumentError, 'type class for Boa::Type::OtherClass is unknown'
     #
     # @param class_type [ClassType] the class type
     #
@@ -25,7 +29,9 @@ module Boa
     # @api public
     sig { overridable.params(class_type: ClassType).returns(T.class_of(Type)) }
     def self.[](class_type)
-      class_types.fetch(class_type, Object)
+      class_types.fetch(class_type) do
+        raise(ArgumentError, "type class for #{class_type} is unknown")
+      end
     end
 
     # Set the type for a class type

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -10,7 +10,6 @@ module Boa
 
     # The class type alias
     ClassType = T.type_alias { T.untyped } # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUntyped
-    public_constant(:ClassType)
 
     abstract!
 

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -8,54 +8,54 @@ module Boa
     extend T::Sig
     include Equality
 
-    # The base type alias
-    Base = T.type_alias { T.untyped } # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUntyped
-    public_constant(:Base)
+    # The class type alias
+    ClassType = T.type_alias { T.untyped } # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUntyped
+    public_constant(:ClassType)
 
     abstract!
 
-    # Lookup the type for a base type
+    # Lookup the type for a class type
     #
     # @example
     #   Boa::Type[::String]  # => Boa::Type::String
     #
-    # @param base_type [Base] the base type
+    # @param class_type [ClassType] the class type
     #
-    # @return [Class<Type>] the type for the base type
+    # @return [Class<Type>] the type for the class type
     #
     # @api public
-    sig { overridable.params(base_type: Base).returns(T.class_of(Type)) }
-    def self.[](base_type)
-      base_types.fetch(base_type, Object)
+    sig { overridable.params(class_type: ClassType).returns(T.class_of(Type)) }
+    def self.[](class_type)
+      class_types.fetch(class_type, Object)
     end
 
-    # Set the type for a base type
+    # Set the type for a class type
     #
     # @example
     #   Boa::Type[::String] = Boa::Type::String
     #   Boa::Type[::String]  # => Boa::Type::String
     #
-    # @param base_type [Base] the base type
-    # @param descendant [Class<Type>] the type for the base type
+    # @param class_type [ClassType] the class type
+    # @param descendant [Class<Type>] the type for the class type
     #
-    # @return [Class<Type>] the type for the base type
+    # @return [Class<Type>] the type for the class type
     #
     # @api public
-    sig { overridable.params(base_type: Base, descendant: T.class_of(Type)).returns(T.class_of(Type)) }
-    def self.[]=(base_type, descendant)
-      base_types[base_type] = descendant
+    sig { overridable.params(class_type: ClassType, descendant: T.class_of(Type)).returns(T.class_of(Type)) }
+    def self.[]=(class_type, descendant)
+      class_types[class_type] = descendant
     end
 
-    # The base types
+    # The class types
     #
-    # @return [Hash{Base => Class<Type>}] the base types
+    # @return [Hash{ClassType => Class<Type>}] the class types
     #
     # @api private
-    sig { overridable.returns(T::Hash[Base, T.class_of(Type)]) }
-    def self.base_types
-      @base_types ||= T.let({}, T.nilable(T::Hash[Base, T.class_of(Type)]))
+    sig { overridable.returns(T::Hash[ClassType, T.class_of(Type)]) }
+    def self.class_types
+      @class_types ||= T.let({}, T.nilable(T::Hash[ClassType, T.class_of(Type)]))
     end
-    private_class_method(:base_types)
+    private_class_method(:class_types)
 
     # The name of the instance variable
     #

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -56,6 +56,22 @@ module Boa
     end
     private_class_method(:class_types)
 
+    # Hook called when a descendant inherits from this class
+    #
+    # @param descendant [Class<Type>] the class inheriting from this class
+    #
+    # @return [void]
+    #
+    # @api private
+    sig { overridable.params(descendant: T.class_of(Type)).void }
+    def self.inherited(descendant)
+      # Share class_types with descendants
+      descendant.instance_variable_set(:@class_types, class_types)
+
+      super
+    end
+    private_class_method(:inherited)
+
     # The name of the instance variable
     #
     # @example

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -45,6 +45,22 @@ module Boa
       class_types[class_type] = descendant
     end
 
+    # Set the class type for the type
+    #
+    # @example
+    #   Boa::Type::String.class_type(::String)  # => Boa::Type::String
+    #   Boa::Type[::String]                     # => Boa::Type::String
+    #
+    # @param class_type [ClassType] the class type
+    #
+    # @return [Type] the type
+    #
+    # @api public
+    sig { overridable.params(class_type: ClassType).returns(T.class_of(Type)) }
+    def self.class_type(class_type)
+      self[class_type] = self
+    end
+
     # The class types
     #
     # @return [Hash{ClassType => Class<Type>}] the class types

--- a/lib/boa/type/boolean.rb
+++ b/lib/boa/type/boolean.rb
@@ -5,7 +5,7 @@ module Boa
   class Type
     # A boolean type
     class Boolean < self
-      Type[T::Boolean] = self
+      class_type(T::Boolean)
 
       # Initialize the boolean type
       #

--- a/lib/boa/type/integer.rb
+++ b/lib/boa/type/integer.rb
@@ -5,7 +5,7 @@ module Boa
   class Type
     # An integer type
     class Integer < self
-      Type[::Integer] = self
+      class_type(::Integer)
 
       # The range of the integer
       #

--- a/lib/boa/type/object.rb
+++ b/lib/boa/type/object.rb
@@ -5,6 +5,7 @@ module Boa
   class Type
     # An object type
     class Object < self
+      class_type(::Object)
     end
   end
 end

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -5,7 +5,7 @@ module Boa
   class Type
     # A string type
     class String < self
-      Type[::String] = self
+      class_type(::String)
 
       # The length of the string
       #

--- a/lib/boa/version.rb
+++ b/lib/boa/version.rb
@@ -4,5 +4,4 @@
 module Boa
   # The Boa version
   VERSION = '0.1.0'
-  public_constant :VERSION
 end

--- a/test/unit/boa/class_methods_test.rb
+++ b/test/unit/boa/class_methods_test.rb
@@ -41,7 +41,7 @@ describe Boa::ClassMethods do
     end
 
     it 'returns self' do
-      assert_same(subject, subject.prop(:admin, Boa::Type::Boolean))
+      assert_same(subject, subject.prop(:admin, T::Boolean))
     end
 
     it 'passes through the default option' do

--- a/test/unit/boa/type_test.rb
+++ b/test/unit/boa/type_test.rb
@@ -30,7 +30,7 @@ describe Boa::Type do
     describe 'when type class is not registered' do
       sig { returns(Module) }
       def base_type
-        Object
+        @base_type ||= Class.new
       end
 
       it 'returns the default type class' do

--- a/test/unit/boa/type_test.rb
+++ b/test/unit/boa/type_test.rb
@@ -14,11 +14,11 @@ describe Boa::Type do
   describe '.[]' do
     cover 'Boa::Type.[]'
 
-    subject { described_class[base_type] }
+    subject { described_class[class_type] }
 
-    describe 'when type class is registered' do
+    describe 'when class type is registered' do
       sig { returns(Module) }
-      def base_type
+      def class_type
         String
       end
 
@@ -27,10 +27,10 @@ describe Boa::Type do
       end
     end
 
-    describe 'when type class is not registered' do
+    describe 'when class type is not registered' do
       sig { returns(Module) }
-      def base_type
-        @base_type ||= Class.new
+      def class_type
+        @class_type ||= Class.new
       end
 
       it 'returns the default type class' do
@@ -42,11 +42,11 @@ describe Boa::Type do
   describe '.[]=' do
     cover 'Boa::Type.[]='
 
-    subject { described_class[base_type] = type_class }
+    subject { described_class[class_type] = type_class }
 
     sig { returns(Module) }
-    def base_type
-      @base_type ||= Class.new
+    def class_type
+      @class_type ||= Class.new
     end
 
     sig { returns(T.class_of(Boa::Type)) }
@@ -56,16 +56,16 @@ describe Boa::Type do
 
     after do
       # Remove the type class from the registry
-      described_class.send(:base_types).delete(base_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
+      described_class.send(:class_types).delete(class_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
     end
 
-    it 'sets the base type' do
-      # assert there is no explict mapping for the base type
-      assert_same(Boa::Type::Object, described_class[base_type])
+    it 'sets the class type' do
+      # assert there is no explict mapping for the class type
+      assert_same(Boa::Type::Object, described_class[class_type])
 
       subject
 
-      assert_same(type_class, described_class[base_type])
+      assert_same(type_class, described_class[class_type])
     end
   end
 end

--- a/test/unit/boa/type_test.rb
+++ b/test/unit/boa/type_test.rb
@@ -69,6 +69,35 @@ describe Boa::Type do
     end
   end
 
+  describe '.class_type' do
+    cover 'Boa::Type.class_type'
+
+    subject { described_class.class_type(class_type) }
+
+    sig { returns(Module) }
+    def class_type
+      @class_type ||= Class.new
+    end
+
+    after do
+      # Remove the type class from the registry
+      described_class.send(:class_types).delete(class_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
+    end
+
+    it 'returns the type class' do
+      assert_same(described_class, subject)
+    end
+
+    it 'sets the class type' do
+      # assert there is no explict mapping for the class type
+      assert_same(Boa::Type::Object, described_class[class_type])
+
+      subject
+
+      assert_same(described_class, described_class[class_type])
+    end
+  end
+
   describe '.inherited' do
     cover 'Boa::Type.inherited'
 

--- a/test/unit/boa/type_test.rb
+++ b/test/unit/boa/type_test.rb
@@ -59,7 +59,7 @@ describe Boa::Type do
       described_class.send(:base_types).delete(base_type) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/Send
     end
 
-    it 'sets the type class' do
+    it 'sets the base type' do
       # assert there is no explict mapping for the base type
       assert_same(Boa::Type::Object, described_class[base_type])
 

--- a/test/unit/boa/type_test.rb
+++ b/test/unit/boa/type_test.rb
@@ -34,7 +34,13 @@ describe Boa::Type do
       end
 
       it 'returns the default type class' do
-        assert_same(Boa::Type::Object, subject)
+        # assert there is no explict mapping for the class type
+        error =
+          assert_raises(ArgumentError) do
+            described_class[class_type]
+          end
+
+        assert_equal("type class for #{class_type} is unknown", error.message)
       end
     end
   end
@@ -61,7 +67,9 @@ describe Boa::Type do
 
     it 'sets the class type' do
       # assert there is no explict mapping for the class type
-      assert_same(Boa::Type::Object, described_class[class_type])
+      assert_raises(ArgumentError) do
+        described_class[class_type]
+      end
 
       subject
 
@@ -90,7 +98,9 @@ describe Boa::Type do
 
     it 'sets the class type' do
       # assert there is no explict mapping for the class type
-      assert_same(Boa::Type::Object, described_class[class_type])
+      assert_raises(ArgumentError) do
+        described_class[class_type]
+      end
 
       subject
 

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -28,9 +28,12 @@ describe Boa do
 
     describe 'with no attributes' do
       it 'raises an error' do
-        assert_raises(ArgumentError) do
-          described_class.new
-        end
+        error =
+          assert_raises(ArgumentError) do
+            described_class.new
+          end
+
+        assert_equal('Missing required prop `name` for class ``', error.message)
       end
     end
 


### PR DESCRIPTION
### Summary

- [x] [Fix ClassMethod#prop YARD docs](https://github.com/dkubb/boa/pull/65/commits/698e1861b8394c4d1d6561db4bd0e8e81bc9695b)
- [x] [Fix Type#[] test example description](https://github.com/dkubb/boa/pull/65/commits/a6aa98cb6c4df678560abc287b8bf643bd51dab8)
- [x] [Fix ClassMethods#prop test to use valid class type](https://github.com/dkubb/boa/pull/65/commits/67684bea5f9b3c2dff094a194fafb225f4af7e41)
- [x] [Fix Type#[] test setup](https://github.com/dkubb/boa/pull/65/commits/83c4bc8923ac35780a2313fd98ca5f138d6686b3)
- [x] [Fix Boa#prop test to check error message](https://github.com/dkubb/boa/pull/65/commits/edc02e50d9d0fb54c77220a8473702533c650a81)
- [x] [Fix Type singleton methods to be overridable](https://github.com/dkubb/boa/pull/65/commits/6a86c8899dfc26714da392946005ba219c5fda71)
- [x] [Rename Type::Base type alias as Type::ClassType](https://github.com/dkubb/boa/pull/65/commits/f1716f396b92eab23b10dd6b450ee2ad4aaa5107)
- [x] [Change RuboCop Style/ConstantVisibility cop to be disabled](https://github.com/dkubb/boa/pull/65/commits/ad1f7adc4bffa7c3d85f70fa98eec1fd8c866e26)
- [x] [Add Type.inherited](https://github.com/dkubb/boa/pull/65/commits/b1b55051512dc5ecba19a0f36c71dee7daf9bcb1)
- [x] [Add Type.class_type](https://github.com/dkubb/boa/pull/65/commits/bbf143585cd0576cfd5381b87468e99348ded88a)
- [x] [Change Type[] to raise when the class_type is not found](https://github.com/dkubb/boa/pull/65/commits/33340c91dca7d54876daaf2c6a354fd6ad51cf39)
