### PR TITLE
Change Util.normalize_integer_range to not accept a default

### DIFF
--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -61,7 +61,9 @@ module Boa
       # @api public
       sig { params(name: Symbol, length: T::Range[T.nilable(::Integer)], options: ::Object).void }
       def initialize(name, length: DEFAULT_LENGTH, **options)
-        @length = T.let(Util.normalize_integer_range(length, default: DEFAULT_LENGTH), T::Range[T.nilable(::Integer)])
+        length = Util.normalize_integer_range(length)
+
+        @length = T.let(Range.new(length.begin || 0, length.end), T::Range[T.nilable(::Integer)])
 
         super(name, **options)
       end

--- a/lib/boa/util.rb
+++ b/lib/boa/util.rb
@@ -6,29 +6,19 @@ module Boa
   module Util
     extend T::Sig
 
-    DEFAULT_RANGE = T.let(Range.new(nil, nil).freeze, T::Range[T.nilable(::Integer)])
-    private_constant(:DEFAULT_RANGE)
-
     # Normalize an integer range
     #
     # @param range [Range<::Integer>] an integer range
-    # @param default [Range<::Integer>] the default integer range
     #
     # @return [Range<::Integer>] the normalized integer range
     #
     # @api private
-    sig do
-      params(
-        range:   T::Range[T.nilable(::Integer)],
-        default: T::Range[T.nilable(::Integer)]
-      ).returns(T::Range[T.nilable(::Integer)])
-    end
-    def self.normalize_integer_range(range, default: DEFAULT_RANGE)
-      base       = default.equal?(DEFAULT_RANGE) ? default : normalize_integer_range(default)
+    sig { params(range: T::Range[T.nilable(::Integer)]).returns(T::Range[T.nilable(::Integer)]) }
+    def self.normalize_integer_range(range)
       range_end  = range.end
       range_end -= 1 if range_end && range.exclude_end?
 
-      Range.new(range.begin || base.begin, range_end || base.end)
+      Range.new(range.begin, range_end)
     end
   end
 end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -66,13 +66,13 @@ describe Boa::Type::String do
     end
 
     describe 'with length option' do
-      subject { described_class.new(type_name, length: min_length..10) }
+      subject { described_class.new(type_name, length: min_length...10) }
 
       describe 'with a non-nil minimum length' do
         let(:min_length) { 2 }
 
         it 'sets the length attribute' do
-          assert_equal(2..10, subject.length)
+          assert_equal(2..9, subject.length)
         end
 
         it 'has the expected minimum length' do
@@ -80,7 +80,7 @@ describe Boa::Type::String do
         end
 
         it 'has the expected default maximum length' do
-          assert_equal(10, subject.max_length)
+          assert_equal(9, subject.max_length)
         end
       end
 
@@ -89,7 +89,7 @@ describe Boa::Type::String do
         def min_length; end
 
         it 'sets the length attribute' do
-          assert_equal(0..10, subject.length)
+          assert_equal(0..9, subject.length)
         end
 
         it 'has the expected minimum length' do
@@ -97,7 +97,7 @@ describe Boa::Type::String do
         end
 
         it 'has the expected default maximum length' do
-          assert_same(10, subject.max_length)
+          assert_same(9, subject.max_length)
         end
       end
     end

--- a/test/unit/boa/util_test.rb
+++ b/test/unit/boa/util_test.rb
@@ -11,12 +11,11 @@ describe Boa::Util do
   describe '.normalize_integer_range' do
     cover 'Boa::Util.normalize_integer_range'
 
-    subject { described_class.normalize_integer_range(range, **options) }
+    subject { described_class.normalize_integer_range(range) }
 
-    let(:range)   { Range.new(public_send(:begin), public_send(:end), exclude_end?) }
-    let(:options) { {}                                                              }
-    let(:begin)   { 1                                                               }
-    let(:end)     { 10                                                              }
+    let(:range) { Range.new(public_send(:begin), public_send(:end), exclude_end?) }
+    let(:begin) { 1                                                               }
+    let(:end)   { 10                                                              }
 
     describe 'when the range is inclusive' do
       let(:exclude_end?) { false }
@@ -30,36 +29,16 @@ describe Boa::Util do
       describe 'when the range begin is nil' do
         let(:begin) { nil }
 
-        describe 'when there is a begin default' do
-          let(:options) { { default: 0... } }
-
-          it 'returns the expected range' do
-            assert_equal(0..10, subject)
-          end
-        end
-
-        describe 'when there is not a begin default' do
-          it 'returns the expected range' do
-            assert_equal(..10, subject)
-          end
+        it 'returns the expected range' do
+          assert_equal(..10, subject)
         end
       end
 
       describe 'when the range end is nil' do
         let(:end) { nil }
 
-        describe 'when there is a end default' do
-          let(:options) { { default: ..11 } }
-
-          it 'returns the expected range' do
-            assert_equal(1..11, subject)
-          end
-        end
-
-        describe 'when there is not an end default' do
-          it 'returns the expected range' do
-            assert_equal(1.., subject)
-          end
+        it 'returns the expected range' do
+          assert_equal(1.., subject)
         end
       end
 
@@ -67,32 +46,8 @@ describe Boa::Util do
         let(:begin) { nil }
         let(:end)   { nil }
 
-        describe 'when there is a begin default' do
-          let(:options) { { default: 0.. } }
-
-          it 'returns the expected range' do
-            assert_equal(0.., subject)
-          end
-        end
-
-        describe 'when there is not a begin default' do
-          it 'returns the expected range' do
-            assert_equal(nil.., subject)
-          end
-        end
-
-        describe 'when there is a end default' do
-          let(:options) { { default: ..11 } }
-
-          it 'returns the expected range' do
-            assert_equal(..11, subject)
-          end
-        end
-
-        describe 'when there is not an end default' do
-          it 'returns the expected range' do
-            assert_equal(nil.., subject)
-          end
+        it 'returns the expected range' do
+          assert_equal(nil.., subject)
         end
       end
     end
@@ -109,36 +64,16 @@ describe Boa::Util do
       describe 'when the range begin is nil' do
         let(:begin) { nil }
 
-        describe 'when there is a begin default' do
-          let(:options) { { default: 0... } }
-
-          it 'returns the expected range' do
-            assert_equal(0..9, subject)
-          end
-        end
-
-        describe 'when there is not a begin default' do
-          it 'returns the expected range' do
-            assert_equal(..9, subject)
-          end
+        it 'returns the expected range' do
+          assert_equal(..9, subject)
         end
       end
 
       describe 'when the range end is nil' do
         let(:end) { nil }
 
-        describe 'when there is a end default' do
-          let(:options) { { default: ...12 } }
-
-          it 'returns the expected range' do
-            assert_equal(1..11, subject)
-          end
-        end
-
-        describe 'when there is not an end default' do
-          it 'returns the expected range' do
-            assert_equal(1.., subject)
-          end
+        it 'returns the expected range' do
+          assert_equal(1.., subject)
         end
       end
 
@@ -146,32 +81,8 @@ describe Boa::Util do
         let(:begin) { nil }
         let(:end)   { nil }
 
-        describe 'when there is a begin default' do
-          let(:options) { { default: 0... } }
-
-          it 'returns the expected range' do
-            assert_equal(0.., subject)
-          end
-        end
-
-        describe 'when there is not a begin default' do
-          it 'returns the expected range' do
-            assert_equal(nil.., subject)
-          end
-        end
-
-        describe 'when there is a end default' do
-          let(:options) { { default: ...12 } }
-
-          it 'returns the expected range' do
-            assert_equal(..11, subject)
-          end
-        end
-
-        describe 'when there is not an end default' do
-          it 'returns the expected range' do
-            assert_equal(nil.., subject)
-          end
+        it 'returns the expected range' do
+          assert_equal(nil.., subject)
         end
       end
     end


### PR DESCRIPTION
### Summary

- [x] [Change Type::String#initialize test to use an exclusive length](https://github.com/dkubb/boa/pull/87/commits/c594b2af97eb88c7930db9d238e169163c26fccc)
- [x] [Refactor Type::String#initialize to use simpler length normalization](https://github.com/dkubb/boa/pull/87/commits/85c6f05f8e89195e60257c45190ca58100c7cf16)
- [x] [Change Util.normalize_integer_range to not accept a default](https://github.com/dkubb/boa/pull/87/commits/1f2246d9ed239e5b46a7fa262f379115053774c5)
