### PR TITLE
Refactor Boa instance methods class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,7 @@ Naming/BlockForwarding:
 
 Security/CompoundHash:
   Exclude:
-    - lib/boa/equality.rb
+    - lib/boa/instance_methods.rb
 
 Sorbet/ForbidTStruct:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,9 @@ Metrics/ModuleLength:
 Naming/BlockForwarding:
   EnforcedStyle: explicit
 
+Performance/ArraySemiInfiniteRangeSlice:
+  Enabled: false
+
 Security/CompoundHash:
   Exclude:
     - lib/boa/instance_methods.rb

--- a/lib/boa.rb
+++ b/lib/boa.rb
@@ -4,7 +4,7 @@
 require 'sorbet-runtime'
 
 require_relative 'boa/util'
-require_relative 'boa/equality'
+require_relative 'boa/instance_methods'
 require_relative 'boa/class_methods'
 require_relative 'boa/type'
 require_relative 'boa/type/object'
@@ -17,7 +17,7 @@ require_relative 'boa/version'
 module Boa
   extend T::Helpers
   extend T::Sig
-  include Equality
+  include InstanceMethods
 
   mixes_in_class_methods(ClassMethods)
 

--- a/lib/boa/equality.rb
+++ b/lib/boa/equality.rb
@@ -27,7 +27,7 @@ module Boa
     # @api public
     sig { params(other: Equality).returns(T::Boolean) }
     def ==(other)
-      other.is_a?(self.class) && object_state == other.object_state
+      other.is_a?(self.class) && cmp?(other, :==)
     end
 
     # Compare the object with other object for equality
@@ -48,7 +48,7 @@ module Boa
     def eql?(other)
       return false unless other.instance_of?(self.class)
 
-      T.let(object_state.eql?(other.object_state), T::Boolean)
+      cmp?(other, :eql?)
     end
 
     # The hash value of the object
@@ -76,6 +76,21 @@ module Boa
       instance_variables.to_h do |ivar_name|
         [ivar_name, instance_variable_get(ivar_name)]
       end
+    end
+
+  private
+
+    # Compare the object with other object for equivalency
+    #
+    # @param [Equality] other the other object to compare with
+    # @param [Symbol] operator the operator to use for comparison
+    #
+    # @return [Boolean]
+    #
+    # @api private
+    sig { params(other: Equality, operator: Symbol).returns(T::Boolean) }
+    def cmp?(other, operator)
+      T.let(object_state.public_send(operator, other.object_state), T::Boolean)
     end
   end
 end

--- a/lib/boa/equality.rb
+++ b/lib/boa/equality.rb
@@ -46,9 +46,7 @@ module Boa
     # @api public
     sig { params(other: Equality).returns(T::Boolean) }
     def eql?(other)
-      return false unless other.instance_of?(self.class)
-
-      cmp?(other, :eql?)
+      other.instance_of?(self.class) && cmp?(other, :eql?)
     end
 
     # The hash value of the object

--- a/lib/boa/instance_methods.rb
+++ b/lib/boa/instance_methods.rb
@@ -88,6 +88,19 @@ module Boa
       end
     end
 
+    # Deconstruct the object into an array
+    #
+    # @example
+    #   instance.deconstruct.map(&:class) # => [Integer]
+    #
+    # @return [Array<Object>] the deconstructed object
+    #
+    # @api public
+    sig { returns(T::Array[Object]) }
+    def deconstruct
+      prop_names.map { |key| T.let(instance_variable_get(:"@#{key}"), Object) }
+    end
+
   private
 
     # The names of the properties of the object

--- a/lib/boa/instance_methods.rb
+++ b/lib/boa/instance_methods.rb
@@ -62,6 +62,32 @@ module Boa
       self.class.hash ^ T.let(object_state.hash, Integer)
     end
 
+    # Deconstruct the object into a hash
+    #
+    # @example matching specific keys
+    #   case instance
+    #   in { object_id: }
+    #     object_id.class
+    #   end # => Integer
+    #
+    # @example matching all keys
+    #   case instance
+    #   in **rest
+    #      rest.fetch(:object_id).class
+    #   end # => Integer
+    #
+    # @param [Array<Symbol>, nil] keys
+    #
+    # @return [Hash{Symbol => Object}]
+    #
+    # @api public
+    sig { params(keys: T.nilable(T::Array[Symbol])).returns(T::Hash[Symbol, Object]) }
+    def deconstruct_keys(keys)
+      (keys.nil? ? prop_names : keys & prop_names).to_h do |key|
+        [key, instance_variable_get(:"@#{key}")]
+      end
+    end
+
   protected
 
     # The state of the object
@@ -77,6 +103,16 @@ module Boa
     end
 
   private
+
+    # The names of the properties of the object
+    #
+    # @return [Array<Symbol>] the names of the properties of the object
+    #
+    # @api private
+    sig { overridable.returns(T::Array[Symbol]) }
+    def prop_names
+      instance_variables.map { |ivar| T.must(ivar.to_s[1..]).to_sym }
+    end
 
     # Compare the object with other object for equivalency
     #

--- a/lib/boa/instance_methods.rb
+++ b/lib/boa/instance_methods.rb
@@ -59,7 +59,7 @@ module Boa
     # @api public
     sig { returns(Integer) }
     def hash
-      self.class.hash ^ T.let(object_state.hash, Integer)
+      self.class.hash ^ T.let(deconstruct_keys(nil).hash, Integer)
     end
 
     # Deconstruct the object into a hash
@@ -88,20 +88,6 @@ module Boa
       end
     end
 
-  protected
-
-    # The state of the object
-    #
-    # @return [Hash{Symbol => Object}] the state of the object
-    #
-    # @api private
-    sig { overridable.returns(T::Hash[Symbol, Object]) }
-    def object_state
-      instance_variables.to_h do |ivar_name|
-        [ivar_name, instance_variable_get(ivar_name)]
-      end
-    end
-
   private
 
     # The names of the properties of the object
@@ -124,7 +110,7 @@ module Boa
     # @api private
     sig { params(other: InstanceMethods, operator: Symbol).returns(T::Boolean) }
     def cmp?(other, operator)
-      T.let(object_state.public_send(operator, other.object_state), T::Boolean)
+      T.let(deconstruct_keys(nil).public_send(operator, other.deconstruct_keys(nil)), T::Boolean)
     end
   end
 end

--- a/lib/boa/instance_methods.rb
+++ b/lib/boa/instance_methods.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 module Boa
-  # A module for comparing objects for equality
-  module Equality
+  # A module for instance methods
+  module InstanceMethods
     extend T::Helpers
     extend T::Sig
 
@@ -14,18 +14,18 @@ module Boa
     # Compare the object with other object for equivalency
     #
     # @example when the objects are equal
-    #   equality_object == equality_object # => true
+    #   instance == instance # => true
     #
     # @example when the objects are not equal
-    #   equality_object == other # => false
+    #   instance == other # => false
     #
-    # @param [Equality] other
+    # @param [InstanceMethods] other
     #   the other object to compare with
     #
     # @return [Boolean]
     #
     # @api public
-    sig { params(other: Equality).returns(T::Boolean) }
+    sig { params(other: InstanceMethods).returns(T::Boolean) }
     def ==(other)
       other.is_a?(self.class) && cmp?(other, :==)
     end
@@ -33,18 +33,18 @@ module Boa
     # Compare the object with other object for equality
     #
     # @example when the objects are equal
-    #   equality_object.eql?(equality_object) # => true
+    #   instance.eql?(instance) # => true
     #
     # @example when the objects are not equal
-    #   equality_object.eql?(other) # => false
+    #   instance.eql?(other) # => false
     #
-    # @param [Equality] other
+    # @param [InstanceMethods] other
     #   the other object to compare with
     #
     # @return [Boolean]
     #
     # @api public
-    sig { params(other: Equality).returns(T::Boolean) }
+    sig { params(other: InstanceMethods).returns(T::Boolean) }
     def eql?(other)
       other.instance_of?(self.class) && cmp?(other, :eql?)
     end
@@ -52,7 +52,7 @@ module Boa
     # The hash value of the object
     #
     # @example
-    #   equality_object.hash.class # => Integer
+    #   instance.hash.class # => Integer
     #
     # @return [Integer] the hash value of the object
     #
@@ -80,13 +80,13 @@ module Boa
 
     # Compare the object with other object for equivalency
     #
-    # @param [Equality] other the other object to compare with
+    # @param [InstanceMethods] other the other object to compare with
     # @param [Symbol] operator the operator to use for comparison
     #
     # @return [Boolean]
     #
     # @api private
-    sig { params(other: Equality, operator: Symbol).returns(T::Boolean) }
+    sig { params(other: InstanceMethods, operator: Symbol).returns(T::Boolean) }
     def cmp?(other, operator)
       T.let(object_state.public_send(operator, other.object_state), T::Boolean)
     end

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -6,7 +6,7 @@ module Boa
   class Type
     extend T::Helpers
     extend T::Sig
-    include Equality
+    include InstanceMethods
 
     # The class type alias
     ClassType = T.type_alias { T.untyped } # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUntyped

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -11,11 +11,9 @@ class Equality
   extend T::Sig
   include Boa::Equality
 
-protected
-
-  sig { override.returns(T::Hash[Symbol, Object]) }
-  def object_state
-    { object_id: }
+  sig { void }
+  def initialize
+    @object_id = T.let(object_id, Integer)
   end
 end
 

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -1,7 +1,6 @@
 # typed: strong
 # frozen_string_literal: true
 
-require 'simplecov'
 require 'sorbet-runtime'
 
 require 'boa'

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -7,9 +7,9 @@ require 'boa'
 
 extend T::Sig
 
-class Equality
+class InstanceMethods
   extend T::Sig
-  include Boa::Equality
+  include Boa::InstanceMethods
 
   sig { void }
   def initialize
@@ -22,14 +22,14 @@ def type
   @type ||= T.let(Class.new(Boa::Type).new(:first_name, default: 'Jon'), T.nilable(Boa::Type))
 end
 
-sig { returns(T::Class[Boa::Equality]) }
-def equality_class
-  @equality_class ||= T.let(Equality, T.nilable(T::Class[Boa::Equality]))
+sig { returns(T::Class[Boa::InstanceMethods]) }
+def klass
+  @klass ||= T.let(InstanceMethods, T.nilable(T::Class[Boa::InstanceMethods]))
 end
 
-sig { returns(Boa::Equality) }
-def equality_object
-  @equality_object ||= T.let(equality_class.new, T.nilable(Boa::Equality))
+sig { returns(Boa::InstanceMethods) }
+def instance
+  @instance ||= T.let(klass.new, T.nilable(Boa::InstanceMethods))
 end
 
 sig { returns(Object) }
@@ -40,8 +40,8 @@ end
 YARD::Doctest.configure do |doctest|
   doctest = T.let(doctest, YARD::Doctest)
 
-  doctest.before('Boa::Equality') do
-    @other = T.let(equality_class.new, T.nilable(Boa::Equality))
+  doctest.before('Boa::InstanceMethods') do
+    @other = T.let(klass.new, T.nilable(Boa::InstanceMethods))
   end
 
   doctest.before('Boa::Type::Boolean') do

--- a/test/support/equality_behaviour.rb
+++ b/test/support/equality_behaviour.rb
@@ -13,10 +13,10 @@ module Support
 
       abstract!
 
-      sig { abstract.returns(T.class_of(Object)) }
+      sig { abstract.returns(T::Class[Boa::Equality]) }
       def described_class; end
 
-      sig { overridable.returns(T.class_of(Object)) }
+      sig { overridable.returns(T::Class[Boa::Equality]) }
       def inheritable_class
         described_class
       end
@@ -29,7 +29,7 @@ module Support
       sig { abstract.returns(Object) }
       def state_inequality; end
 
-      sig { abstract.params(klass: T.class_of(Object)).returns(Object) }
+      sig { abstract.params(klass: T::Class[Boa::Equality]).returns(Boa::Equality) }
       def new_object(klass) end
     end
 

--- a/test/support/equality_behaviour.rb
+++ b/test/support/equality_behaviour.rb
@@ -67,7 +67,7 @@ module Support
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
         descendant.cover('Boa::Equality#==')
-        descendant.cover('Boa::Equality#object__state')
+        descendant.cover('Boa::Equality#object_state')
       end
 
       sig { override.void }
@@ -124,7 +124,7 @@ module Support
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
         descendant.cover('Boa::Equality#eql?')
-        descendant.cover('Boa::Equality#object__state')
+        descendant.cover('Boa::Equality#object_state')
       end
 
       sig { override.void }
@@ -180,7 +180,7 @@ module Support
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
         descendant.cover('Boa::Equality#hash')
-        descendant.cover('Boa::Equality#object__state')
+        descendant.cover('Boa::Equality#object_state')
       end
 
       sig { override.void }

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -4,7 +4,7 @@
 require 'minitest/test'
 
 module Support
-  module EqualityBehaviour
+  module InstanceMethodsBehaviour
     module Setup
       extend T::Helpers
       extend T::Sig
@@ -13,10 +13,10 @@ module Support
 
       abstract!
 
-      sig { abstract.returns(T::Class[Boa::Equality]) }
+      sig { abstract.returns(T::Class[Boa::InstanceMethods]) }
       def described_class; end
 
-      sig { overridable.returns(T::Class[Boa::Equality]) }
+      sig { overridable.returns(T::Class[Boa::InstanceMethods]) }
       def inheritable_class
         described_class
       end
@@ -29,7 +29,7 @@ module Support
       sig { abstract.returns(Object) }
       def state_inequality; end
 
-      sig { abstract.params(klass: T::Class[Boa::Equality]).returns(Boa::Equality) }
+      sig { abstract.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::InstanceMethods) }
       def new_object(klass) end
     end
 
@@ -57,7 +57,7 @@ module Support
       def test_objects_similar_but_not_equal_state; end
     end
 
-    module Equality
+    module InstanceMethods
       extend T::Helpers
       extend T::Sig
       include Contexts
@@ -66,8 +66,8 @@ module Support
 
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
-        descendant.cover('Boa::Equality#==')
-        descendant.cover('Boa::Equality#object_state')
+        descendant.cover('Boa::InstanceMethods#==')
+        descendant.cover('Boa::InstanceMethods#object_state')
       end
 
       sig { override.void }
@@ -123,8 +123,8 @@ module Support
 
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
-        descendant.cover('Boa::Equality#eql?')
-        descendant.cover('Boa::Equality#object_state')
+        descendant.cover('Boa::InstanceMethods#eql?')
+        descendant.cover('Boa::InstanceMethods#object_state')
       end
 
       sig { override.void }
@@ -179,8 +179,8 @@ module Support
 
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
-        descendant.cover('Boa::Equality#hash')
-        descendant.cover('Boa::Equality#object_state')
+        descendant.cover('Boa::InstanceMethods#hash')
+        descendant.cover('Boa::InstanceMethods#object_state')
       end
 
       sig { override.void }

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -223,5 +223,43 @@ module Support
         # skip if state_ineql impossible to define for this type
       end
     end
+
+    module DeconstructKeys
+      extend T::Helpers
+      extend T::Sig
+
+      requires_ancestor { Setup }
+
+      abstract!
+
+      sig { params(descendant: MutantCoverage).void }
+      def self.included(descendant)
+        descendant.cover('Boa::InstanceMethods#deconstruct_keys')
+      end
+
+      sig { abstract.returns(T::Hash[Symbol, Object]) }
+      def expected_object_state; end
+
+      sig { void }
+      def test_deconstruct_keys_with_nil
+        subject = new_object(described_class)
+
+        assert_equal(expected_object_state, subject.deconstruct_keys(nil))
+      end
+
+      sig { void }
+      def test_deconstruct_keys_with_property_names
+        subject = new_object(described_class)
+
+        assert_equal(expected_object_state, subject.deconstruct_keys(expected_object_state.keys))
+      end
+
+      sig { void }
+      def test_deconstruct_keys_with_invalid_property_names
+        subject = new_object(described_class)
+
+        assert_empty(subject.deconstruct_keys(%i[invalid]))
+      end
+    end
   end
 end

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -258,5 +258,29 @@ module Support
         assert_empty(subject.deconstruct_keys(%i[invalid]))
       end
     end
+
+    module Deconstruct
+      extend T::Helpers
+      extend T::Sig
+
+      requires_ancestor { Setup }
+
+      abstract!
+
+      sig { params(descendant: MutantCoverage).void }
+      def self.included(descendant)
+        descendant.cover('Boa::InstanceMethods#deconstruct')
+      end
+
+      sig { abstract.returns(T::Hash[Symbol, Object]) }
+      def expected_object_state; end
+
+      sig { void }
+      def test_deconstruct
+        subject = new_object(described_class)
+
+        assert_equal(expected_object_state.values, subject.deconstruct)
+      end
+    end
   end
 end

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -67,7 +67,6 @@ module Support
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
         descendant.cover('Boa::InstanceMethods#==')
-        descendant.cover('Boa::InstanceMethods#object_state')
       end
 
       sig { override.void }
@@ -124,7 +123,6 @@ module Support
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
         descendant.cover('Boa::InstanceMethods#eql?')
-        descendant.cover('Boa::InstanceMethods#object_state')
       end
 
       sig { override.void }
@@ -180,7 +178,6 @@ module Support
       sig { params(descendant: MutantCoverage).void }
       def self.included(descendant)
         descendant.cover('Boa::InstanceMethods#hash')
-        descendant.cover('Boa::InstanceMethods#object_state')
       end
 
       sig { override.void }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ require 'mutant/minitest/coverage'
 require 'sorbet-runtime'
 
 require_relative 'support/mutant_coverage'
-require_relative 'support/equality_behaviour'
+require_relative 'support/instance_methods_behaviour'
 require_relative 'support/type_behaviour'
 
 require 'boa'

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -118,6 +118,15 @@ module Boa
             { name: type_name, includes: [true, false], options: {} }
           end
         end
+
+        class Deconstruct < self
+          include Support::InstanceMethodsBehaviour::Deconstruct
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { name: type_name, includes: [true, false], options: {} }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -109,6 +109,15 @@ module Boa
         class Hash < self
           include Support::InstanceMethodsBehaviour::Hash
         end
+
+        class DeconstructKeys < self
+          include Support::InstanceMethodsBehaviour::DeconstructKeys
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { name: type_name, includes: [true, false], options: {} }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -25,7 +25,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::Boolean))
         end
 
-        sig { override.params(klass: T.class_of(::Object)).returns(Boa::Type::Boolean) }
+        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::Boolean) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Boolean, but was #{klass}") unless klass <= Boa::Type::Boolean
 

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -10,7 +10,7 @@ module Boa
     class Type
       class Boolean < Minitest::Test
         extend T::Sig
-        include Support::EqualityBehaviour::Setup
+        include Support::InstanceMethodsBehaviour::Setup
         include Support::TypeBehaviour::Setup
 
         parallelize_me!
@@ -25,7 +25,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::Boolean))
         end
 
-        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::Boolean) }
+        sig { override.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::Type::Boolean) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Boolean, but was #{klass}") unless klass <= Boa::Type::Boolean
 
@@ -98,16 +98,16 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
-        class Equality < self
-          include Support::EqualityBehaviour::Equality
+        class InstanceMethods < self
+          include Support::InstanceMethodsBehaviour::InstanceMethods
         end
 
         class Eql < self
-          include Support::EqualityBehaviour::Eql
+          include Support::InstanceMethodsBehaviour::Eql
         end
 
         class Hash < self
-          include Support::EqualityBehaviour::Hash
+          include Support::InstanceMethodsBehaviour::Hash
         end
       end
     end

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -205,6 +205,15 @@ module Boa
         class Hash < self
           include Support::InstanceMethodsBehaviour::Hash
         end
+
+        class DeconstructKeys < self
+          include Support::InstanceMethodsBehaviour::DeconstructKeys
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { range: nil.., name: type_name, includes: nil, options: {} }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -25,7 +25,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::Integer))
         end
 
-        sig { override.params(klass: T.class_of(::Object)).returns(Boa::Type::Integer) }
+        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::Integer) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Integer, but was #{klass}") unless klass <= Boa::Type::Integer
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -214,6 +214,15 @@ module Boa
             { range: nil.., name: type_name, includes: nil, options: {} }
           end
         end
+
+        class Deconstruct < self
+          include Support::InstanceMethodsBehaviour::Deconstruct
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { range: nil.., name: type_name, includes: nil, options: {} }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -10,7 +10,7 @@ module Boa
     class Type
       class Integer < Minitest::Test
         extend T::Sig
-        include Support::EqualityBehaviour::Setup
+        include Support::InstanceMethodsBehaviour::Setup
         include Support::TypeBehaviour::Setup
 
         parallelize_me!
@@ -25,7 +25,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::Integer))
         end
 
-        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::Integer) }
+        sig { override.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::Type::Integer) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Integer, but was #{klass}") unless klass <= Boa::Type::Integer
 
@@ -194,16 +194,16 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
-        class Equality < self
-          include Support::EqualityBehaviour::Equality
+        class InstanceMethods < self
+          include Support::InstanceMethodsBehaviour::InstanceMethods
         end
 
         class Eql < self
-          include Support::EqualityBehaviour::Eql
+          include Support::InstanceMethodsBehaviour::Eql
         end
 
         class Hash < self
-          include Support::EqualityBehaviour::Hash
+          include Support::InstanceMethodsBehaviour::Hash
         end
       end
     end

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -30,7 +30,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::Object))
         end
 
-        sig { override.params(klass: T.class_of(::Object)).returns(Boa::Type::Object) }
+        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::Object) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Object, but was #{klass}") unless klass <= Boa::Type::Object
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -126,6 +126,15 @@ module Boa
             { name: type_name, includes: nil, options: { default: 1 } }
           end
         end
+
+        class Deconstruct < self
+          include Support::InstanceMethodsBehaviour::Deconstruct
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { name: type_name, includes: nil, options: { default: 1 } }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -10,7 +10,7 @@ module Boa
     class Type
       class Object < Minitest::Test
         extend T::Sig
-        include Support::EqualityBehaviour::Setup
+        include Support::InstanceMethodsBehaviour::Setup
         include Support::TypeBehaviour::Setup
 
         parallelize_me!
@@ -30,7 +30,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::Object))
         end
 
-        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::Object) }
+        sig { override.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::Type::Object) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Object, but was #{klass}") unless klass <= Boa::Type::Object
 
@@ -106,16 +106,16 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
-        class Equality < self
-          include Support::EqualityBehaviour::Equality
+        class InstanceMethods < self
+          include Support::InstanceMethodsBehaviour::InstanceMethods
         end
 
         class Eql < self
-          include Support::EqualityBehaviour::Eql
+          include Support::InstanceMethodsBehaviour::Eql
         end
 
         class Hash < self
-          include Support::EqualityBehaviour::Hash
+          include Support::InstanceMethodsBehaviour::Hash
         end
       end
     end

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -117,6 +117,15 @@ module Boa
         class Hash < self
           include Support::InstanceMethodsBehaviour::Hash
         end
+
+        class DeconstructKeys < self
+          include Support::InstanceMethodsBehaviour::DeconstructKeys
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { name: type_name, includes: nil, options: { default: 1 } }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -25,7 +25,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::String))
         end
 
-        sig { override.params(klass: T.class_of(::Object)).returns(Boa::Type::String) }
+        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::String) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::String, but was #{klass}") unless klass <= Boa::Type::String
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -204,6 +204,15 @@ module Boa
         class Hash < self
           include Support::InstanceMethodsBehaviour::Hash
         end
+
+        class DeconstructKeys < self
+          include Support::InstanceMethodsBehaviour::DeconstructKeys
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { length: 0.., name: type_name, includes: nil, options: {} }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -213,6 +213,15 @@ module Boa
             { length: 0.., name: type_name, includes: nil, options: {} }
           end
         end
+
+        class Deconstruct < self
+          include Support::InstanceMethodsBehaviour::Deconstruct
+
+          sig { override.returns(T::Hash[Symbol, ::Object]) }
+          def expected_object_state
+            { length: 0.., name: type_name, includes: nil, options: {} }
+          end
+        end
       end
     end
   end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -10,7 +10,7 @@ module Boa
     class Type
       class String < Minitest::Test
         extend T::Sig
-        include Support::EqualityBehaviour::Setup
+        include Support::InstanceMethodsBehaviour::Setup
         include Support::TypeBehaviour::Setup
 
         parallelize_me!
@@ -25,7 +25,7 @@ module Boa
           @state_inequality ||= T.let(described_class.new(:inequal), T.nilable(Boa::Type::String))
         end
 
-        sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Type::String) }
+        sig { override.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::Type::String) }
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::String, but was #{klass}") unless klass <= Boa::Type::String
 
@@ -193,16 +193,16 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
-        class Equality < self
-          include Support::EqualityBehaviour::Equality
+        class InstanceMethods < self
+          include Support::InstanceMethodsBehaviour::InstanceMethods
         end
 
         class Eql < self
-          include Support::EqualityBehaviour::Eql
+          include Support::InstanceMethodsBehaviour::Eql
         end
 
         class Hash < self
-          include Support::EqualityBehaviour::Hash
+          include Support::InstanceMethodsBehaviour::Hash
         end
       end
     end

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -84,5 +84,14 @@ module Boa
     class Hash < self
       include Support::InstanceMethodsBehaviour::Hash
     end
+
+    class DeconstructKeys < self
+      include Support::InstanceMethodsBehaviour::DeconstructKeys
+
+      sig { override.returns(T::Hash[Symbol, Object]) }
+      def expected_object_state
+        options
+      end
+    end
   end
 end

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -42,7 +42,7 @@ module Boa
       @state_inequality ||= T.let(described_class.new(T.unsafe(**options, name: 'Other Name')), T.nilable(Person))
     end
 
-    sig { override.params(klass: T.class_of(Object)).returns(Object) }
+    sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Equality) }
     def new_object(klass)
       klass.new(**options)
     end

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -6,7 +6,7 @@ require 'test_helper'
 module Boa
   class Test < Minitest::Test
     extend T::Sig
-    include Support::EqualityBehaviour::Setup
+    include Support::InstanceMethodsBehaviour::Setup
 
     parallelize_me!
 
@@ -42,7 +42,7 @@ module Boa
       @state_inequality ||= T.let(described_class.new(T.unsafe(**options, name: 'Other Name')), T.nilable(Person))
     end
 
-    sig { override.params(klass: T::Class[Boa::Equality]).returns(Boa::Equality) }
+    sig { override.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::InstanceMethods) }
     def new_object(klass)
       klass.new(**options)
     end
@@ -73,16 +73,16 @@ module Boa
       end
     end
 
-    class Equality < self
-      include Support::EqualityBehaviour::Equality
+    class InstanceMethods < self
+      include Support::InstanceMethodsBehaviour::InstanceMethods
     end
 
     class Eql < self
-      include Support::EqualityBehaviour::Eql
+      include Support::InstanceMethodsBehaviour::Eql
     end
 
     class Hash < self
-      include Support::EqualityBehaviour::Hash
+      include Support::InstanceMethodsBehaviour::Hash
     end
   end
 end

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -93,5 +93,14 @@ module Boa
         options
       end
     end
+
+    class Deconstruct < self
+      include Support::InstanceMethodsBehaviour::Deconstruct
+
+      sig { override.returns(T::Hash[Symbol, Object]) }
+      def expected_object_state
+        options
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary

- [x] [Remove YARD doctest simplecov integration](https://github.com/dkubb/boa/pull/89/commits/cbc7c0f3698809d3243af13dc12d7f5139f3107b)
- [x] [Fix Equality cover expression to match method name](https://github.com/dkubb/boa/pull/89/commits/40054daa65eb5736adb790461c0b57778e041d31)
- [x] [Refactor Equality comparison to be handled by one method](https://github.com/dkubb/boa/pull/89/commits/863221db6ba61cb545552eccda6b76590962cd36)
- [x] [Refactor Equality#eql? to be more consistent with #==](https://github.com/dkubb/boa/pull/89/commits/e1de0f430ac86585ee443c22d88974c5066745eb)
- [x] [Refactor Equality behaviour test setup](https://github.com/dkubb/boa/pull/89/commits/be2ba3067179f63c4cf97d3478b69e365e6173f3)
- [x] [Refactor YARD doctest setup to be simpler](https://github.com/dkubb/boa/pull/89/commits/1fd956476f3bfc1df05d2dba2863cbf66f78238a)
- [x] [Rename Equality to InstanceMethods](https://github.com/dkubb/boa/pull/89/commits/47006add0a499bd761e0d4085f077d249f56ae58)
- [x] [Add InstanceMethods#deconstruct_keys](https://github.com/dkubb/boa/pull/89/commits/2385f420e4866c601e42dcffad30ebad5e241e86)
- [x] [Refactor InstanceMethods to use deconstruct_keys internally](https://github.com/dkubb/boa/pull/89/commits/58c5afd9084e55d00e6843705e3c9c34c09cc266)
- [x] [Add InstanceMethods#deconstruct](https://github.com/dkubb/boa/pull/89/commits/dd86fb9f41861ff670066295a484e6d3d9c90c99)