### PR TITLE
Fix Type::String.new to validate the length range is non-negative

### DIFF
--- a/.mutant.yml
+++ b/.mutant.yml
@@ -13,3 +13,5 @@ mutation:
 matcher:
   subjects:
     - Boa*
+  ignore:
+    - Boa::Type::String#initialize  # Sorbet requires the default value for length

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,9 +77,6 @@ Sorbet/ForbidTUntyped:
   Exclude:
     - test/support/type_behaviour.rb
 
-Sorbet/ForbidTypeAliasedShapes:
-  Enabled: false
-
 Sorbet/RedundantExtendTSig:
   Enabled: false
 

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -9,7 +9,7 @@ module Boa
     include InstanceMethods
 
     # The class type alias
-    ClassType = T.type_alias { T.untyped } # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUntyped
+    ClassType = T.type_alias { T.anything }
 
     abstract!
 

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -63,6 +63,8 @@ module Boa
       def self.new(name, length: DEFAULT_LENGTH, **options)
         min, max = length_minmax(length)
 
+        raise(ArgumentError, "length.begin must be greater than or equal to 0, but was #{min}") if min.negative?
+
         super(name, length: min..max, **options)
       end
 

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -63,8 +63,9 @@ module Boa
       def self.new(name, length: DEFAULT_LENGTH, **options)
         min, max = length_minmax(length)
 
-        raise(ArgumentError, "length.begin must be greater than or equal to 0, but was #{min}")      if min.negative?
-        raise(ArgumentError, "length.end must be greater than or equal to 0 or nil, but was #{max}") if max&.negative?
+        raise(ArgumentError, "length.begin must be greater than or equal to 0, but was #{min}")              if min.negative?
+        raise(ArgumentError, "length.end must be greater than or equal to 0 or nil, but was #{max}")         if max&.negative?
+        raise(ArgumentError, "length.end must be greater than or equal to length.begin, but was: #{length}") if max&.<(min)
 
         super(name, length: min..max, **options)
       end

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -63,7 +63,8 @@ module Boa
       def self.new(name, length: DEFAULT_LENGTH, **options)
         min, max = length_minmax(length)
 
-        raise(ArgumentError, "length.begin must be greater than or equal to 0, but was #{min}") if min.negative?
+        raise(ArgumentError, "length.begin must be greater than or equal to 0, but was #{min}")      if min.negative?
+        raise(ArgumentError, "length.end must be greater than or equal to 0 or nil, but was #{max}") if max&.negative?
 
         super(name, length: min..max, **options)
       end

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -22,7 +22,7 @@ module Boa
       sig { returns(T::Range[T.nilable(::Integer)]) }
       attr_reader :length
 
-      # Initialize the string type
+      # Construct the string type
       #
       # @example with the default length
       #   type = String.new(:name)
@@ -56,14 +56,43 @@ module Boa
       # @param length [Range<::Integer>] the length of the string
       # @param options [Hash{Symbol => Object}] the options for the type
       #
-      # @return [void]
+      # @return [Type::String] the string type
       #
       # @api public
+      sig { params(name: Symbol, length: T::Range[T.nilable(::Integer)], options: ::Object).returns(T.attached_class) }
+      def self.new(name, length: DEFAULT_LENGTH, **options)
+        min, max = length_minmax(length)
+
+        super(name, length: min..max, **options)
+      end
+
+      # The min and max from the length constraint
+      #
+      # @param length [Range<::Integer>] the length constraint of the string
+      #
+      # @return [Array(::Integer, ::Integer), Array(::Integer, nil)] the min, max length constraints
+      #
+      # @api private
+      sig { params(length: T::Range[T.nilable(::Integer)]).returns([::Integer, T.nilable(::Integer)]) }
+      def self.length_minmax(length)
+        normalized = Util.normalize_integer_range(length)
+
+        [normalized.begin || 0, normalized.end]
+      end
+      private_class_method(:length_minmax)
+
+      # Initialize the string type
+      #
+      # @param name [Symbol] the name of the type
+      # @param length [Range<::Integer>] the length of the string
+      # @param options [Hash{Symbol => Object}] the options for the type
+      #
+      # @return [void]
+      #
+      # @api private
       sig { params(name: Symbol, length: T::Range[T.nilable(::Integer)], options: ::Object).void }
       def initialize(name, length: DEFAULT_LENGTH, **options)
-        length = Util.normalize_integer_range(length)
-
-        @length = T.let(Range.new(length.begin || 0, length.end), T::Range[T.nilable(::Integer)])
+        @length = T.let(length, T::Range[T.nilable(::Integer)])
 
         super(name, **options)
       end

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -108,7 +108,7 @@ module Support
 
       sig { returns(Boa::Type::ClassType) }
       def class_type
-        @class_type ||= T.let(Class.new, T.nilable(T::Class[T.untyped]))
+        @class_type ||= T.let(Class.new, T.nilable(T::Class[T.anything]))
       end
 
       sig { returns(T.class_of(Boa::Type)) }
@@ -145,7 +145,7 @@ module Support
 
       sig { returns(Boa::Type::ClassType) }
       def class_type
-        @class_type ||= T.let(Class.new, T.nilable(T::Class[T.untyped]))
+        @class_type ||= T.let(Class.new, T.nilable(T::Class[T.anything]))
       end
     end
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -120,6 +120,26 @@ module Boa
 
             assert_equal('length.end must be greater than or equal to 0 or nil, but was -1', error.message)
           end
+
+          sig { void }
+          def test_with_length_option_and_maximum_length_less_than_minimum_length
+            error = T.let(
+              assert_raises(ArgumentError) { described_class.new(type_name, length: 1..0) },
+              ArgumentError
+            )
+
+            assert_equal('length.end must be greater than or equal to length.begin, but was: 1..0', error.message)
+          end
+
+          sig { void }
+          def test_with_length_option_and_empty_range
+            error = T.let(
+              assert_raises(ArgumentError) { described_class.new(type_name, length: 1...1) },
+              ArgumentError
+            )
+
+            assert_equal('length.end must be greater than or equal to length.begin, but was: 1...1', error.message)
+          end
         end
 
         class Name < self

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -100,6 +100,16 @@ module Boa
             assert_equal(10, subject.max_length)
             assert_operator(subject, :frozen?)
           end
+
+          sig { void }
+          def test_with_length_option_and_negative_minimum_length
+            error = T.let(
+              assert_raises(ArgumentError) { described_class.new(type_name, length: -1..) },
+              ArgumentError
+            )
+
+            assert_equal('length.begin must be greater than or equal to 0, but was -1', error.message)
+          end
         end
 
         class Name < self

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -110,6 +110,16 @@ module Boa
 
             assert_equal('length.begin must be greater than or equal to 0, but was -1', error.message)
           end
+
+          sig { void }
+          def test_with_length_option_and_negative_maximum_length
+            error = T.let(
+              assert_raises(ArgumentError) { described_class.new(type_name, length: 0..-1) },
+              ArgumentError
+            )
+
+            assert_equal('length.end must be greater than or equal to 0 or nil, but was -1', error.message)
+          end
         end
 
         class Name < self


### PR DESCRIPTION
### Summary

- [x] [Remove Sorbet/ForbidTypeAliasedShapes cop](https://github.com/dkubb/boa/pull/93/commits/5ea978b190b68920a8d4ac8fd7101f12b06a1ccc)
- [x] [Fix Type::ClassType type alias to be stronger](https://github.com/dkubb/boa/pull/93/commits/eacc3b738b37c715ca75aa97800907f31cee9696)
- [x] [Add Type::String.new constructor](https://github.com/dkubb/boa/pull/93/commits/646b06178b5266f6a3372a9f6d8136f5dd355e3c)
- [x] [Change Type::String.new constructor to validate length begin](https://github.com/dkubb/boa/pull/93/commits/5cf6689be2bfc7447e53d8f309980dd6125a73fb)
- [x] [Change Type::String.new constructor to validate length end](https://github.com/dkubb/boa/pull/93/commits/4415200a83627b60b64f5055fc2f7af0da6a94ae)
- [x] [Change Type::String.new constructor to validate length end gt begin](https://github.com/dkubb/boa/pull/93/commits/20440fc272f20a43c786e0e57c2a0636ecc727cd)
