### PR TITLE
Change RuboCop Sorbet cops to be stricter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,19 +80,6 @@ Sorbet/ForbidTUntyped:
 Sorbet/RedundantExtendTSig:
   Enabled: false
 
-Sorbet/StrictSigil:
-  Exclude:
-    - test/**/*.rb
-
-Sorbet/StrongSigil:
-  Exclude:
-    - spec/doctest_helper.rb
-    - test/**/*.rb
-
-Sorbet/TrueSigil:
-  Exclude:
-    - test/**/*.rb
-
 Style/AccessorGrouping:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,10 +69,6 @@ Security/CompoundHash:
 Sorbet/ForbidTStruct:
   Enabled: false
 
-Sorbet/ForbidTUnsafe:
-  Exclude:
-    - test/unit/boa_test.rb
-
 Sorbet/ForbidTUntyped:
   Exclude:
     - test/support/type_behaviour.rb

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -108,6 +108,7 @@ module Boa
 
         raise(ArgumentError, message) if message
       end
+      private_class_method(:assert_valid_length)
 
       # Initialize the string type
       #

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -102,7 +102,7 @@ module Boa
             "length.begin must be greater than or equal to 0, but was #{min}"
           elsif max&.negative?
             "length.end must be greater than or equal to 0 or nil, but was #{max}"
-          elsif max&.<(min) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/MissingElse
+          elsif max && max < min # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/MissingElse
             "length.end must be greater than or equal to length.begin, but was: #{min..max} (normalized)"
           end
 

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -39,7 +39,7 @@ module Boa
 
     sig { override.returns(Person) }
     def state_inequality
-      @state_inequality ||= T.let(described_class.new(T.unsafe(**options, name: 'Other Name')), T.nilable(Person))
+      @state_inequality ||= T.let(described_class.new(name: 'Other Name'), T.nilable(Person))
     end
 
     sig { override.params(klass: T::Class[Boa::InstanceMethods]).returns(Boa::InstanceMethods) }


### PR DESCRIPTION
### Summary

- [x] [Remove Sorbet/*Sigil cop config](/commits/bf06f075cfd2afe17d6ce258215fc0764a49057f)
- [x] [Remove T.unsafe usage](/commits/dcb9992a599798f65f170a41a56dcfde9b20235b)
- [x] [Fix Type::String.assert_valid_length to be private](/commits/9a2dceaf9e4d21c77c7771ce811314a2b79b6110)
- [x] [Refactor Type::String.assert_valid_length to be simpler](/commits/d8557cb3633a499c3856b255e7d5d7ff354a2c61)
