### PR TITLE
Fix Type::Integer.new to validate the range constraint

### DIFF
--- a/.mutant.yml
+++ b/.mutant.yml
@@ -14,4 +14,5 @@ matcher:
   subjects:
     - Boa*
   ignore:
+    - Boa::Type::Integer#initialize # Sorbet requires the default value for range
     - Boa::Type::String#initialize  # Sorbet requires the default value for length

--- a/lib/boa/type/integer.rb
+++ b/lib/boa/type/integer.rb
@@ -23,7 +23,7 @@ module Boa
       sig { returns(T::Range[T.nilable(::Integer)]) }
       attr_reader :range
 
-      # Initialize the integer type
+      # Constructs the integer type
       #
       # @example with the default range
       #   type = Integer.new(:age)
@@ -45,7 +45,45 @@ module Boa
       #
       # @return [void]
       #
+      # @raise [ArgumentError] if the range constraint  is invalid
+      #
       # @api public
+      sig { params(name: Symbol, range: T::Range[T.nilable(::Integer)], options: ::Object).returns(T.attached_class) }
+      def self.new(name, range: DEFAULT_RANGE, **options)
+        range = Util.normalize_integer_range(range)
+
+        assert_valid_range(range.begin, range.end)
+
+        super(name, range:, **options)
+      end
+
+      # Assert the range constraint is valid
+      #
+      # @param min [::Integer, nil] the minimum range
+      # @param max [::Integer, nil] the maximum range
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] if the range constraint is invalid
+      #
+      # @api private
+      sig { params(min: T.nilable(::Integer), max: T.nilable(::Integer)).void }
+      def self.assert_valid_range(min, max)
+        return if min.nil? || max.nil? || max >= min
+
+        raise(ArgumentError, "range.end must be greater than or equal to range.begin, but was: #{min..max} (normalized)")
+      end
+      private_class_method(:assert_valid_range)
+
+      # Initialize the integer type
+      #
+      # @param name [Symbol] the name of the type
+      # @param range [Range<::Integer>] the range of the integer
+      # @param options [Hash{Symbol => Object}] the options for the type
+      #
+      # @return [void]
+      #
+      # @api private
       sig { params(name: Symbol, range: T::Range[T.nilable(::Integer)], options: ::Object).void }
       def initialize(name, range: DEFAULT_RANGE, **options)
         @range = T.let(Util.normalize_integer_range(range), T::Range[T.nilable(::Integer)])

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -94,6 +94,25 @@ module Boa
             assert_equal(..10, subject.range)
             assert_operator(subject, :frozen?)
           end
+
+          sig { void }
+          def test_with_range_option_and_singleton_range
+            subject = described_class.new(type_name, range: 1..1)
+
+            assert_same(type_name, subject.name)
+            assert_equal(1..1, subject.range)
+            assert_operator(subject, :frozen?)
+          end
+
+          sig { void }
+          def test_with_range_option_and_empty_range
+            error = T.let(
+              assert_raises(ArgumentError) { described_class.new(type_name, range: 1...1) },
+              ArgumentError
+            )
+
+            assert_equal('range.end must be greater than or equal to range.begin, but was: 1..0 (normalized)', error.message)
+          end
         end
 
         class Name < self

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -102,6 +102,17 @@ module Boa
           end
 
           sig { void }
+          def test_with_length_option_and_singleton_range
+            subject = described_class.new(type_name, length: 1..1)
+
+            assert_equal(type_name, subject.name)
+            assert_equal(1..1, subject.length)
+            assert_equal(1, subject.min_length)
+            assert_equal(1, subject.max_length)
+            assert_operator(subject, :frozen?)
+          end
+
+          sig { void }
           def test_with_length_option_and_negative_minimum_length
             error = T.let(
               assert_raises(ArgumentError) { described_class.new(type_name, length: -1..) },


### PR DESCRIPTION
### Summary

- [x] [Fix Type::Integer.new to validate the range constraint](https://github.com/dkubb/boa/pull/96/commits/efeaf50e9fc7d5dacf75ec2d42c3332234a121f6)
- [x] [Add Type::String.new test for a singleton range length option](https://github.com/dkubb/boa/pull/96/commits/6dfa771959822b8ae81ae743398d5279a5862e8f)
