### PR TITLE
Add Type#parse

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,7 @@ Sorbet/ForbidTStruct:
 
 Sorbet/ForbidTUntyped:
   Exclude:
+    - lib/boa/class_methods.rb
     - test/support/type_behaviour.rb
     - test/unit/boa/result_test.rb
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,6 +90,7 @@ Sorbet/ForbidTStruct:
 Sorbet/ForbidTUntyped:
   Exclude:
     - lib/boa/class_methods.rb
+    - lib/boa/type.rb
     - test/support/type_behaviour.rb
     - test/unit/boa/result_test.rb
 

--- a/lib/boa/class_methods.rb
+++ b/lib/boa/class_methods.rb
@@ -35,7 +35,7 @@ module Boa
     # @return [ClassMethods] the class method module
     #
     # @api public
-    sig { params(name: Symbol, class_type: Type::ClassType, options: Object).returns(T.self_type) }
+    sig { params(name: Symbol, class_type: Type::ClassType, options: T.untyped).returns(T.self_type) }
     def prop(name, class_type, **options)
       property = properties[name] = Type[class_type].new(name, **options)
       super(name, class_type, **property.options)

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -170,8 +170,13 @@ module Boa
     # @api public
     sig { returns(T.self_type) }
     def freeze
+      return self if frozen?
+
       instance_variables.each do |ivar_name|
-        T.let(instance_variable_get(ivar_name), ::Object).freeze
+        ivar = T.let(instance_variable_get(ivar_name),        ::Object)
+        ivar = T.let(Ractor.make_shareable(ivar, copy: true), ::Object)
+
+        instance_variable_set(ivar_name, ivar)
       end
 
       T.let(super(), Type)

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -11,6 +11,10 @@ module Boa
     # The class type alias
     ClassType = T.type_alias { T.anything }
 
+    # The includes type alias
+    Includes = T.type_alias { T.all(T::Enumerable[T.anything], ::Object) }
+    private_constant(:Includes)
+
     abstract!
 
     # Lookup the type for a class type
@@ -113,7 +117,7 @@ module Boa
     # @return [Object] the object to check inclusion against
     #
     # @api public
-    sig { returns(::Object) }
+    sig { returns(T.nilable(Includes)) }
     attr_reader :includes
 
     # The options for the T::Struct.prop method
@@ -130,16 +134,16 @@ module Boa
     # Initialize the type
     #
     # @param name [Symbol] the name of the type
-    # @param includes [Object] the object to check inclusion against
+    # @param includes [Enumerable<Integer>, nil] the object to check inclusion against
     # @param options [Hash{Symbol => Object}] the options for the type
     #
     # @return [void]
     #
     # @api private
-    sig { params(name: Symbol, includes: ::Object, options: ::Object).void }
+    sig { params(name: Symbol, includes: T.nilable(Includes), options: ::Object).void }
     def initialize(name, includes: nil, **options)
       @name     = name
-      @includes = T.let(includes, T.nilable(::Object))
+      @includes = T.let(includes, T.nilable(Includes))
       @options  = options
 
       freeze

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -185,5 +185,35 @@ module Boa
 
       T.let(super(), Type)
     end
+
+    # Parse the value
+    #
+    # @example when the value is included
+    #   type = String.new(:first_name, includes: %w[Jon])
+    #   type.parse('Jon') # => Boa::Success.new('Jon')
+    #
+    # @example when the value is not included
+    #   type = String.new(:first_name, includes: %w[Jon])
+    #   type.parse('Dan') # => Boa::Failure.new('must be one of ["Jon"], but was "Dan"')
+    #
+    # @example when includes is nil
+    #   type = String.new(:first_name)
+    #   type.parse('Jon') # => Boa::Success.new('Jon')
+    #
+    # @param value [Object] the value to parse
+    #
+    # @return [Result<Object, String>] the result of parsing the value
+    #
+    # @api public
+    sig { overridable.params(value: ::Object).returns(Result[T.untyped, ExceptionType]) }
+    def parse(value)
+      allowed_values = includes
+
+      if allowed_values.nil? || allowed_values.include?(value)
+        Success.new(value)
+      else
+        Failure.new("must be one of #{allowed_values}, but was #{value.inspect}")
+      end
+    end
   end
 end

--- a/lib/boa/type/boolean.rb
+++ b/lib/boa/type/boolean.rb
@@ -19,7 +19,7 @@ module Boa
       #   type.name   # => :admin?
       #
       # @param _name [Symbol] the name of the type
-      # @param includes [Array<Boolean>] the object to check inclusion against
+      # @param includes [Enumerable<Boolean>] the object to check inclusion against
       # @param options [Hash] the options to initialize with
       #
       # @return [void]

--- a/lib/boa/type/integer.rb
+++ b/lib/boa/type/integer.rb
@@ -54,7 +54,7 @@ module Boa
       # @api public
       sig { params(name: Symbol, range: RangeType, options: ::Object).returns(T.attached_class) }
       def self.new(name, range: DEFAULT_RANGE, **options)
-        super(name, range: parse_range(range).unwrap, **options)
+        super(name, **options, range: parse_range(range).unwrap)
       end
 
       # Parse the range constraint

--- a/lib/boa/type/integer.rb
+++ b/lib/boa/type/integer.rb
@@ -129,6 +129,43 @@ module Boa
       def max_range
         range.end
       end
+
+      # Parse the integer value
+      #
+      # @example with a value within range
+      #   type = Integer.new(:age, range: 1..125)
+      #   type.parse(1)   # => Boa::Success.new(1)
+      #   type.parse(125) # => Boa::Success.new(125)
+      #
+      # @example with a value outside of range
+      #   type = Integer.new(:age, range: 1..125)
+      #   type.parse(0)   # => Boa::Failure.new('must be within 1..125, but was: 0')
+      #   type.parse(126) # => Boa::Failure.new('must be within 1..125, but was: 126')
+      #
+      # @example with a non-integer value
+      #   type = Integer.new(:age)
+      #   type.parse('1') # => Boa::Failure.new('must be an Integer, but was: String')
+      #
+      # @param _value [::Integer] the value to parse
+      #
+      # @return [Result<::Integer, ExceptionType>] the result of parsing the value
+      #
+      # @api public
+      sig { override.params(_value: ::Object).returns(Result[::Integer, ExceptionType]) }
+      def parse(_value) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Metrics/MethodLength
+        super.and_then do |value|
+          case value
+          when ::Integer
+            if range.cover?(value)
+              Success.new(value)
+            else
+              Failure.new("must be within #{range}, but was: #{value}")
+            end
+          else
+            Failure.new("must be an Integer, but was: #{T.let(value, ::Object).class}")
+          end
+        end
+      end
     end
   end
 end

--- a/lib/boa/type/integer.rb
+++ b/lib/boa/type/integer.rb
@@ -44,6 +44,7 @@ module Boa
       #   type.default # => nil
       #
       # @param name [Symbol] the name of the type
+      # @param includes [Enumerable<Integer>, nil] the object to check inclusion against
       # @param range [Range<::Integer>] the range of the integer
       # @param options [Hash{Symbol => Object}] the options for the type
       #
@@ -52,9 +53,9 @@ module Boa
       # @raise [ArgumentError] if the range constraint is invalid
       #
       # @api public
-      sig { params(name: Symbol, range: RangeType, options: ::Object).returns(T.attached_class) }
-      def self.new(name, range: DEFAULT_RANGE, **options)
-        super(name, **options, range: parse_range(range).unwrap)
+      sig { params(name: Symbol, includes: T.nilable(Includes), range: RangeType, options: ::Object).returns(T.attached_class) }
+      def self.new(name, includes: nil, range: DEFAULT_RANGE, **options)
+        super(name, **options, includes:, range: parse_range(range).unwrap)
       end
 
       # Parse the range constraint
@@ -79,17 +80,18 @@ module Boa
       # Initialize the integer type
       #
       # @param name [Symbol] the name of the type
+      # @param includes [Enumerable<Integer>, nil] the object to check inclusion against
       # @param range [Range<::Integer>] the range of the integer
       # @param options [Hash{Symbol => Object}] the options for the type
       #
       # @return [void]
       #
       # @api private
-      sig { params(name: Symbol, range: RangeType, options: ::Object).void }
-      def initialize(name, range: DEFAULT_RANGE, **options)
+      sig { params(name: Symbol, includes: T.nilable(Includes), range: RangeType, options: ::Object).void }
+      def initialize(name, includes: nil, range: DEFAULT_RANGE, **options)
         @range = T.let(range, RangeType)
 
-        super(name, **options)
+        super(name, **options, includes:)
       end
 
       # The minimum range of the integer

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -67,7 +67,7 @@ module Boa
       # @api public
       sig { params(name: Symbol, length: LengthType, options: ::Object).returns(T.attached_class) }
       def self.new(name, length: DEFAULT_LENGTH, **options)
-        super(name, length: parse_length(length).unwrap, **options)
+        super(name, **options, length: parse_length(length).unwrap)
       end
 
       # Parse the length constraint

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -89,7 +89,7 @@ module Boa
           elsif max&.negative?
             "length.end must be greater than or equal to 0 or nil, but was #{max}"
           elsif max && max < min # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Style/MissingElse
-            "length.end must be greater than or equal to length.begin, but was: #{length}"
+            "length range cannot be empty, but was: #{length}"
           end
         end
       end

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -57,6 +57,7 @@ module Boa
       #   type.default # => 'Dan Kubb'
       #
       # @param name [Symbol] the name of the type
+      # @param includes [Enumerable<Integer>, nil] the object to check inclusion against
       # @param length [Range<::Integer>] the length of the string
       # @param options [Hash{Symbol => Object}] the options for the type
       #
@@ -65,9 +66,9 @@ module Boa
       # @raise [ArgumentError] if the length constraint is invalid
       #
       # @api public
-      sig { params(name: Symbol, length: LengthType, options: ::Object).returns(T.attached_class) }
-      def self.new(name, length: DEFAULT_LENGTH, **options)
-        super(name, **options, length: parse_length(length).unwrap)
+      sig { params(name: Symbol, includes: T.nilable(Includes), length: LengthType, options: ::Object).returns(T.attached_class) }
+      def self.new(name, includes: nil, length: DEFAULT_LENGTH, **options)
+        super(name, **options, includes:, length: parse_length(length).unwrap)
       end
 
       # Parse the length constraint
@@ -98,17 +99,18 @@ module Boa
       # Initialize the string type
       #
       # @param name [Symbol] the name of the type
+      # @param includes [Enumerable<Integer>, nil] the object to check inclusion against
       # @param length [Range<::Integer>] the length of the string
       # @param options [Hash{Symbol => Object}] the options for the type
       #
       # @return [void]
       #
       # @api private
-      sig { params(name: Symbol, length: LengthType, options: ::Object).void }
-      def initialize(name, length: DEFAULT_LENGTH, **options)
+      sig { params(name: Symbol, includes: T.nilable(Includes), length: LengthType, options: ::Object).void }
+      def initialize(name, includes: nil, length: DEFAULT_LENGTH, **options)
         @length = T.let(length, LengthType)
 
-        super(name, **options)
+        super(name, **options, includes:)
       end
 
       # The minimum length of the string

--- a/lib/boa/type/string.rb
+++ b/lib/boa/type/string.rb
@@ -144,6 +144,45 @@ module Boa
       def max_length
         length.end
       end
+
+      # Parse the string value
+      #
+      # @example with a valid string
+      #   type = String.new(:name)
+      #   type.parse('Dan Kubb') # => Boa::Success.new('Dan Kubb')
+      #
+      # @example with a string that is too short
+      #   type = String.new(:name, length: 4..)
+      #   type.parse('Dan') # => Boa::Failure.new('must have a length within 4.., but was: 3')
+      #
+      # @example with a string that is too long
+      #   type = String.new(:name, length: ..7)
+      #   type.parse('Dan Kubb') # => Boa::Failure.new('must have a length within 0..7, but was: 8')
+      #
+      # @example with a non-string value
+      #   type = String.new(:name)
+      #   type.parse(1) # => Boa::Failure.new('must be a String, but was: Integer')
+      #
+      # @param _value [Object] the value to parse
+      #
+      # @return [Result<::String, ExceptionType>] the result of parsing the value
+      #
+      # @api public
+      sig { override.params(_value: ::Object).returns(Result[::String, ExceptionType]) }
+      def parse(_value) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Metrics/MethodLength
+        super.and_then do |value|
+          case value
+          when ::String
+            if length.cover?(value.length)
+              Success.new(value)
+            else
+              Failure.new("must have a length within #{length}, but was: #{value.length}")
+            end
+          else
+            Failure.new("must be a String, but was: #{T.let(value, ::Object).class}")
+          end
+        end
+      end
     end
   end
 end

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -432,5 +432,54 @@ module Support
         end
       end
     end
+
+    module Parse
+      extend T::Helpers
+      extend T::Sig
+
+      requires_ancestor { Setup }
+
+      abstract!
+
+      sig { params(descendant: MutantCoverage).void }
+      def self.included(descendant)
+        descendant.cover('Boa::Type.parse')
+      end
+
+      sig { abstract.returns(T.nilable(Object)) }
+      def valid_value; end
+
+      sig { abstract.returns(T.nilable(Object)) }
+      def invalid_value; end
+
+      sig { overridable.returns(T.nilable(T::Array[T.untyped])) }
+      def includes
+        @includes ||= T.let([valid_value], T.nilable(T::Array[T.untyped]))
+      end
+
+      sig { void }
+      def test_when_includes_is_not_set
+        subject = described_class.new(type_name)
+
+        assert_equal(Boa::Success.new(valid_value), subject.parse(valid_value))
+      end
+
+      sig { void }
+      def test_when_includes_is_set_and_value_is_valid
+        subject = described_class.new(type_name, includes:)
+
+        assert_equal(Boa::Success.new(valid_value), subject.parse(valid_value))
+      end
+
+      sig { void }
+      def test_when_includes_is_set_and_value_is_invalid
+        subject = described_class.new(type_name, includes:)
+
+        assert_equal(
+          Boa::Failure.new("must be one of #{includes.inspect}, but was #{invalid_value.inspect}"),
+          subject.parse(invalid_value)
+        )
+      end
+    end
   end
 end

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -399,6 +399,30 @@ module Support
         assert_same(subject, subject.freeze)
       end
 
+      sig { void }
+      def test_does_not_mutate_arguments
+        includes = []
+        options  = { includes: }
+        subject  = described_class.new(type_name, **options)
+
+        subject.freeze
+
+        # Argument is not mutated
+        refute_operator(includes, :frozen?)
+        assert_operator(subject.includes, :frozen?)
+
+        # Argument state is copied
+        refute_same(includes, subject.includes)
+        assert_equal(includes, subject.includes)
+      end
+
+      sig { void }
+      def test_idempotent
+        subject = described_class.new(type_name)
+
+        assert_same(subject.freeze, subject.freeze)
+      end
+
     private
 
       sig { params(object: Object).returns(T::Hash[Symbol, Object]) }

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -24,6 +24,9 @@ module Support
         {}
       end
 
+      sig { overridable.returns(T.nilable(T::Array[T.untyped])) }
+      def includes; end
+
       sig { returns(T::Hash[Boa::Type::ClassType, T.class_of(Boa::Type)]) }
       def class_types
         T.let(
@@ -288,9 +291,6 @@ module Support
         descendant.cover('Boa::Type#includes')
       end
 
-      sig { abstract.returns(Object) }
-      def includes; end
-
       sig { void }
       def test_returns_the_includes
         subject = described_class.new(type_name, includes:)
@@ -317,7 +317,7 @@ module Support
 
       sig { void }
       def test_returns_the_options
-        subject = described_class.new(type_name, **options)
+        subject = described_class.new(type_name, **options, includes:)
 
         assert_equal(options, subject.options)
       end

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -83,6 +83,11 @@ module Boa
 
         class Options < self
           include Support::TypeBehaviour::Options
+
+          sig { override.returns(T::Array[T::Boolean]) }
+          def includes
+            @includes ||= T.let([true, false].freeze, T.nilable(T::Array[T::Boolean]))
+          end
         end
 
         class Default < self

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -77,7 +77,7 @@ module Boa
 
           sig { override.returns(T::Array[T::Boolean]) }
           def includes
-            @includes ||= T.let([true], T.nilable(T::Array[T::Boolean]))
+            @includes ||= T.let([true].freeze, T.nilable(T::Array[T::Boolean]))
           end
         end
 

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -103,6 +103,20 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
+        class Parse < self
+          include Support::TypeBehaviour::Parse
+
+          sig { override.returns(T::Boolean) }
+          def valid_value
+            true
+          end
+
+          sig { override.returns(T::Boolean) }
+          def invalid_value
+            false
+          end
+        end
+
         class Equality < self
           include Support::InstanceMethodsBehaviour::Equality
         end

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -214,7 +214,10 @@ module Boa
         end
 
         class Parse < self
+          extend MutantCoverage
           include Support::TypeBehaviour::Parse
+
+          cover('Boa::Type::Integer#parse')
 
           sig { override.returns(::Integer) }
           def valid_value
@@ -224,6 +227,48 @@ module Boa
           sig { override.returns(::Integer) }
           def invalid_value
             0
+          end
+
+          sig { void }
+          def test_with_no_range_option
+            subject = described_class.new(type_name)
+
+            assert_equal(Boa::Success.new(0), subject.parse(0))
+          end
+
+          sig { void }
+          def test_with_range_option_and_minimum_range
+            subject = described_class.new(type_name, range: 1..)
+
+            assert_equal(Boa::Success.new(1), subject.parse(1))
+          end
+
+          sig { void }
+          def test_with_range_option_and_minimum_range_and_invalid_value
+            subject = described_class.new(type_name, range: 1..)
+
+            assert_equal(Boa::Failure.new('must be within 1.., but was: 0'), subject.parse(0))
+          end
+
+          sig { void }
+          def test_with_range_option_and_maximum_range
+            subject = described_class.new(type_name, range: ..1)
+
+            assert_equal(Boa::Success.new(1), subject.parse(1))
+          end
+
+          sig { void }
+          def test_with_range_option_and_maximum_range_and_invalid_value
+            subject = described_class.new(type_name, range: ..1)
+
+            assert_equal(Boa::Failure.new('must be within ..1, but was: 2'), subject.parse(2))
+          end
+
+          sig { void }
+          def test_with_invalid_type
+            subject = described_class.new(type_name)
+
+            assert_equal(Boa::Failure.new('must be an Integer, but was: String'), subject.parse('0'))
           end
         end
 

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -213,6 +213,20 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
+        class Parse < self
+          include Support::TypeBehaviour::Parse
+
+          sig { override.returns(::Integer) }
+          def valid_value
+            1
+          end
+
+          sig { override.returns(::Integer) }
+          def invalid_value
+            0
+          end
+        end
+
         class Equality < self
           include Support::InstanceMethodsBehaviour::Equality
         end

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -124,7 +124,7 @@ module Boa
 
           sig { override.returns(T::Array[::Integer]) }
           def includes
-            @includes ||= T.let([1], T.nilable(T::Array[::Integer]))
+            @includes ||= T.let([1].freeze, T.nilable(T::Array[::Integer]))
           end
         end
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -34,7 +34,7 @@ module Boa
         def new_object(klass)
           raise(ArgumentError, "klass must be a Boa::Type::Object, but was #{klass}") unless klass <= Boa::Type::Object
 
-          klass.new(type_name, **options)
+          klass.new(type_name, **options, includes:)
         end
 
         sig { override.returns(T::Hash[Symbol, ::Object]) }

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -69,7 +69,7 @@ module Boa
 
           sig { override.returns(::Object) }
           def non_nil_default
-            @non_nil_default ||= T.let(::Object.new, T.nilable(::Object))
+            @non_nil_default ||= T.let(::Object.new.freeze, T.nilable(::Object))
           end
 
           sig { override.returns(NilClass) }
@@ -85,7 +85,7 @@ module Boa
 
           sig { override.returns(T::Array[::Object]) }
           def includes
-            @includes ||= T.let([::Object.new], T.nilable(T::Array[::Object]))
+            @includes ||= T.let([::Object.new.freeze].freeze, T.nilable(T::Array[::Object]))
           end
         end
 
@@ -98,7 +98,7 @@ module Boa
 
           sig { override.returns(::Object) }
           def default
-            @default ||= T.let(::Object.new, T.nilable(::Object))
+            @default ||= T.let(::Object.new.freeze, T.nilable(::Object))
           end
         end
 

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -106,6 +106,25 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
+        class Parse < self
+          include Support::TypeBehaviour::Parse
+
+          sig { override.returns(::Object) }
+          def valid_value
+            @valid_value ||= T.let(::Object.new.freeze, T.nilable(::Object))
+          end
+
+          sig { override.returns(::Object) }
+          def invalid_value
+            @invalid_value ||= T.let(::Object.new.freeze, T.nilable(::Object))
+          end
+
+          sig { override.returns(T::Array[::Object]) }
+          def includes
+            @includes ||= T.let([valid_value], T.nilable(T::Array[::Object]))
+          end
+        end
+
         class Equality < self
           include Support::InstanceMethodsBehaviour::Equality
         end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -244,6 +244,20 @@ module Boa
           include Support::TypeBehaviour::Freeze
         end
 
+        class Parse < self
+          include Support::TypeBehaviour::Parse
+
+          sig { override.returns(::String) }
+          def valid_value
+            'Jon'
+          end
+
+          sig { override.returns(::String) }
+          def invalid_value
+            'Dan'
+          end
+        end
+
         class Equality < self
           include Support::InstanceMethodsBehaviour::Equality
         end

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -245,7 +245,10 @@ module Boa
         end
 
         class Parse < self
+          extend MutantCoverage
           include Support::TypeBehaviour::Parse
+
+          cover('Boa::Type::String#parse')
 
           sig { override.returns(::String) }
           def valid_value
@@ -255,6 +258,42 @@ module Boa
           sig { override.returns(::String) }
           def invalid_value
             'Dan'
+          end
+
+          sig { void }
+          def test_with_no_length_option
+            subject = described_class.new(type_name)
+
+            assert_equal(Boa::Success.new('Dan'), subject.parse('Dan'))
+          end
+
+          sig { void }
+          def test_with_length_option
+            subject = described_class.new(type_name, length: 2..10)
+
+            assert_equal(Boa::Success.new('a' * 2),  subject.parse('a' * 2))
+            assert_equal(Boa::Success.new('a' * 10), subject.parse('a' * 10))
+          end
+
+          sig { void }
+          def test_with_length_option_and_too_short
+            subject = described_class.new(type_name, length: 2..10)
+
+            assert_equal(Boa::Failure.new('must have a length within 2..10, but was: 1'), subject.parse('a'))
+          end
+
+          sig { void }
+          def test_with_length_option_and_too_long
+            subject = described_class.new(type_name, length: 2..10)
+
+            assert_equal(Boa::Failure.new('must have a length within 2..10, but was: 11'), subject.parse('a' * 11))
+          end
+
+          sig { void }
+          def test_with_length_option_and_non_string_value
+            subject = described_class.new(type_name, length: 2..10)
+
+            assert_equal(Boa::Failure.new('must be a String, but was: Integer'), subject.parse(1))
           end
         end
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -162,7 +162,7 @@ module Boa
 
           sig { override.returns(T::Array[::String]) }
           def includes
-            @includes ||= T.let(%w[test], T.nilable(T::Array[::String]))
+            @includes ||= T.let(%w[test].freeze, T.nilable(T::Array[::String]))
           end
         end
 

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -139,7 +139,7 @@ module Boa
               ArgumentError
             )
 
-            assert_equal('length.end must be greater than or equal to length.begin, but was: 1..0', exception.message)
+            assert_equal('length range cannot be empty, but was: 1..0', exception.message)
           end
 
           sig { void }
@@ -149,7 +149,7 @@ module Boa
               ArgumentError
             )
 
-            assert_equal('length.end must be greater than or equal to length.begin, but was: 1...1', exception.message)
+            assert_equal('length range cannot be empty, but was: 1...1', exception.message)
           end
         end
 


### PR DESCRIPTION
### Summary

- [x] [Fix double splat code formatting](https://github.com/dkubb/boa/pull/100/commits/cd8f74f14d0c428afaf26b42e541b1aa53229e6f)
- [x] [Fix Type test setup to freeze options tested for sameness](https://github.com/dkubb/boa/pull/100/commits/f73bdbbc0a15fee67e5dfc9df3702e3f3cb00216)
- [x] [Fix Type#freeze to be idempotent and not mutate arguments](https://github.com/dkubb/boa/pull/100/commits/e02acfda3eb1895bf1944266ed088dd3081002e8)
- [x] [Change Type::String.parse_length empty range error message](https://github.com/dkubb/boa/pull/100/commits/30e17e336c60549701909e73789bdf2e7776da39)
- [x] [Add Type::Includes type alias](https://github.com/dkubb/boa/pull/100/commits/8dcc0fd2539355203801a40ff02d1c9d9a4bbe5e)
- [x] [Add Type#parse](https://github.com/dkubb/boa/pull/100/commits/738f09da1c305835443e73f65d52f69641411078)
- [x] [Add Type::Integer#parse](https://github.com/dkubb/boa/pull/100/commits/05706035ffcb66409a82a73ff369a6bb34bdf0a3)
- [x] [Add Type::String#parse](https://github.com/dkubb/boa/pull/100/commits/83f4753261c4137ab368802d00ea962cb5a40b71)
