### PR TITLE
Add property based tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,7 @@ Lint/UnreachableLoop:
 Metrics/AbcSize:
   Exclude:
     - test/support/**/*.rb
+    - test/unit/boa/class_methods_test.rb
     - test/unit/boa/util_test.rb
 
 Metrics/BlockLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,7 @@ Lint/UnreachableLoop:
 Metrics/AbcSize:
   Exclude:
     - test/support/**/*.rb
+    - test/unit/boa/util_test.rb
 
 Metrics/BlockLength:
   Exclude:
@@ -62,6 +63,7 @@ Metrics/MethodLength:
   Exclude:
     - spec/doctest_helper.rb
     - test/support/**/*.rb
+    - test/unit/boa/util_test.rb
 
 Metrics/ModuleLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,7 @@ Sorbet/ForbidTUntyped:
   Exclude:
     - lib/boa/class_methods.rb
     - lib/boa/type.rb
+    - test/support/property_generators.rb
     - test/support/type_behaviour.rb
     - test/unit/boa/result_test.rb
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'minitest',            '~> 5.20.0'                  # Ruby testing framework
   gem 'mutant',              '~> 0.11.26'                 # Mutation testing for Ruby
   gem 'mutant-minitest',     '~> 0.11.26'                 # Minitest integration for Mutant
+  gem 'mutex_m',             '~> 0.2.0'                   # Mutex Mixin
   gem 'rake',                '~> 13.1.0'                  # Scripting utility similar to Make
   gem 'rubocop',             '~> 1.59.0'                  # Linter for enforcing Ruby coding style
   gem 'rubocop-minitest',    '~> 0.34.3'                  # RuboCop extension specific to Minitest

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem 'mutant',              '~> 0.11.26'                 # Mutation testing for Ruby
   gem 'mutant-minitest',     '~> 0.11.26'                 # Minitest integration for Mutant
   gem 'mutex_m',             '~> 0.2.0'                   # Mutex Mixin
+  gem 'prop_check',          '~> 0.18.1'                  # Property-based testing for Ruby
   gem 'rake',                '~> 13.1.0'                  # Scripting utility similar to Make
   gem 'rubocop',             '~> 1.59.0'                  # Linter for enforcing Ruby coding style
   gem 'rubocop-minitest',    '~> 0.34.3'                  # RuboCop extension specific to Minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
+    amazing_print (1.5.0)
     ast (2.4.2)
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
@@ -39,6 +40,8 @@ GEM
       racc
     prettier_print (1.2.1)
     prism (0.19.0)
+    prop_check (0.18.1)
+      amazing_print (~> 1.2)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
@@ -133,6 +136,7 @@ DEPENDENCIES
   mutant-license (~> 0.1.1)!
   mutant-minitest (~> 0.11.26)
   mutex_m (~> 0.2.0)
+  prop_check (~> 0.18.1)
   rake (~> 13.1.0)
   rubocop (~> 1.59.0)
   rubocop-minitest (~> 0.34.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     mutant-minitest (0.11.26)
       minitest (~> 5.11)
       mutant (= 0.11.26)
+    mutex_m (0.2.0)
     netrc (0.11.0)
     parallel (1.24.0)
     parser (3.2.2.4)
@@ -131,6 +132,7 @@ DEPENDENCIES
   mutant (~> 0.11.26)
   mutant-license (~> 0.1.1)!
   mutant-minitest (~> 0.11.26)
+  mutex_m (~> 0.2.0)
   rake (~> 13.1.0)
   rubocop (~> 1.59.0)
   rubocop-minitest (~> 0.34.3)

--- a/lib/boa/type.rb
+++ b/lib/boa/type.rb
@@ -80,7 +80,6 @@ module Boa
     def self.class_types
       @class_types ||= T.let({}, T.nilable(T::Hash[ClassType, T.class_of(Type)]))
     end
-    private_class_method(:class_types)
 
     # Hook called when a descendant inherits from this class
     #

--- a/test/support/property_generators.rb
+++ b/test/support/property_generators.rb
@@ -1,0 +1,79 @@
+# typed: strong
+# frozen_string_literal: true
+
+module PropertyGenerators
+  module Type
+    extend T::Sig
+
+    sig { returns(PropCheck::Generator) }
+    def self.instance
+      instance =
+        one_of(Boa::Type.subclasses.map { |klass| constant(klass) }).bind do |klass|
+          klass = T.let(klass, T.class_of(Boa::Type))
+
+          G.instance(klass, name, includes: includes(klass))
+        end
+
+      T.let(instance, PropCheck::Generator)
+    end
+
+    sig { params(value: Object).returns(PropCheck::Generator) }
+    def self.constant(value)
+      T.let(G.constant(value), PropCheck::Generator)
+    end
+    private_class_method(:constant)
+
+    sig { params(values: T::Array[Object]).returns(T::Array[PropCheck::Generator]) }
+    def self.constant_values(values)
+      values.map { |value| constant(value) }
+    end
+
+    sig { params(choices: T::Array[PropCheck::Generator]).returns(PropCheck::Generator) }
+    def self.one_of(choices)
+      generator = T.let(G.choose(choices.length), PropCheck::Generator)
+
+      selected =
+        generator.bind do |index|
+          choices.fetch(T.let(index, Integer))
+        end
+
+      T.let(selected, PropCheck::Generator)
+    end
+    private_class_method(:one_of)
+
+    sig { params(element_generator: PropCheck::Generator, options: T.untyped).returns(PropCheck::Generator) }
+    def self.array(element_generator, **options)
+      T.let(G.array(element_generator, **options), PropCheck::Generator)
+    end
+
+    sig { returns(PropCheck::Generator) }
+    def self.name
+      alpha_char = one_of(constant_values([*'a'..'z', *'A'..'Z']))
+      digit      = one_of(constant_values(Array('0'..'9')))
+      underscore = constant('_')
+
+      head = T.let(one_of([alpha_char, underscore]),                            PropCheck::Generator)
+      tail = T.let(array(one_of([alpha_char, digit, underscore]), empty: true), PropCheck::Generator)
+
+      name =
+        head.bind do |prefix|
+          tail.map do |suffix|
+            prefix = T.let(prefix, String)
+            suffix = T.let(suffix, T::Array[String])
+
+            T.let([prefix, *suffix], T::Array[String]).join.to_sym
+          end
+        end
+
+      T.let(name, PropCheck::Generator)
+    end
+    private_class_method(:name)
+
+    sig { params(_klass: T.class_of(Boa::Type)).returns(PropCheck::Generator) }
+    def self.includes(_klass)
+      # TODO: depend on type class
+      T.let(one_of([constant(nil)]), PropCheck::Generator)
+    end
+    private_class_method(:includes)
+  end
+end

--- a/test/support/property_generators.rb
+++ b/test/support/property_generators.rb
@@ -7,8 +7,10 @@ module PropertyGenerators
 
     sig { returns(PropCheck::Generator) }
     def self.instance
+      subclasses = Boa::Type.subclasses.select(&:name)
+
       instance =
-        one_of(Boa::Type.subclasses.map { |klass| constant(klass) }).bind do |klass|
+        one_of(constant_values(subclasses)).bind do |klass|
           klass = T.let(klass, T.class_of(Boa::Type))
 
           G.instance(klass, name, includes: includes(klass))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ require_relative 'support/instance_methods_behaviour'
 require_relative 'support/mutant_coverage'
 require_relative 'support/strict_matchers'
 require_relative 'support/type_behaviour'
+require_relative 'support/property_generators'
 
 require 'boa'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'simplecov' unless defined?(Mutant)
 
 require 'minitest/autorun'
 require 'mutant/minitest/coverage'
+require 'prop_check'
 require 'sorbet-runtime'
 
 require_relative 'support/instance_methods_behaviour'
@@ -18,3 +19,5 @@ ROOT_PATH = T.let(Pathname.new(__dir__).parent, Pathname)
 
 Minitest::Test.extend(MutantCoverage)
 Minitest::Assertions.prepend(StrictMatchers)
+
+G = PropCheck::Generators

--- a/test/unit/boa/class_methods_test.rb
+++ b/test/unit/boa/class_methods_test.rb
@@ -33,13 +33,16 @@ module Boa
 
         sig { void }
         def test_properties
-          subject = Class.new(described_class)
+          PropCheck.forall(PropertyGenerators::Type.instance) do |type|
+            type    = T.let(type, Boa::Type)
+            subject = Class.new(described_class)
 
-          assert_empty(subject.properties)
+            assert_empty(subject.properties)
 
-          type = subject.properties[type_name] = Boa::Type::String.new(type_name)
+            subject.properties[type.name] = type
 
-          assert_equal({ name: type }, subject.properties)
+            assert_equal({ type.name => type }, subject.properties)
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

- [x] [Add mutex_m 0.2.0 gem depenency](https://github.com/dkubb/boa/pull/103/commits/43133ac6ea721d75b968ff3dc6e2375253abee12)
- [x] [Add prop_check 0.18.1 depenency](https://github.com/dkubb/boa/pull/103/commits/49c67ae112840a73d97b1a53e30255a025822600)
- [x] [Change minitest setup to define G namespace for property generators](https://github.com/dkubb/boa/pull/103/commits/8b5ae73eefab9085aacc542174e29c47f8f8da45)
- [x] [Changea Util.normalize_integer_range tests to be property based](https://github.com/dkubb/boa/pull/103/commits/a2b9e92148c9df8cf4c7a374ab9f26f38a32c616)
- [x] [Change ClassMethods#properties tests to be property based](https://github.com/dkubb/boa/pull/103/commits/2dfa2b206445317d70c1e4057eb0af2a09d2f195)
- [x] [Change ClassMethods#prop tests to be property based](https://github.com/dkubb/boa/pull/103/commits/e9f77dd13a8e80ac114031fc0bd49269291cd614)
