### PR TITLE
Add StrictMatchers test support module

### DIFF
--- a/lib/boa/instance_methods.rb
+++ b/lib/boa/instance_methods.rb
@@ -19,15 +19,20 @@ module Boa
     # @example when the objects are not equal
     #   instance == other # => false
     #
-    # @param [InstanceMethods] other
+    # @param [BasicObject] other
     #   the other object to compare with
     #
     # @return [Boolean]
     #
     # @api public
-    sig { params(other: InstanceMethods).returns(T::Boolean) }
+    sig { params(other: T.anything).returns(T::Boolean) }
     def ==(other)
-      other.is_a?(self.class) && cmp?(other, :==)
+      case other
+      when InstanceMethods
+        other.is_a?(self.class) && cmp?(other, :==)
+      else
+        false
+      end
     end
 
     # Compare the object with other object for equality
@@ -38,15 +43,20 @@ module Boa
     # @example when the objects are not equal
     #   instance.eql?(other) # => false
     #
-    # @param [InstanceMethods] other
+    # @param [BasicObject] other
     #   the other object to compare with
     #
     # @return [Boolean]
     #
     # @api public
-    sig { params(other: InstanceMethods).returns(T::Boolean) }
+    sig { params(other: T.anything).returns(T::Boolean) }
     def eql?(other)
-      other.instance_of?(self.class) && cmp?(other, :eql?)
+      case other
+      when InstanceMethods
+        other.instance_of?(self.class) && cmp?(other, :eql?)
+      else
+        false
+      end
     end
 
     # The hash value of the object

--- a/lib/boa/type/boolean.rb
+++ b/lib/boa/type/boolean.rb
@@ -19,13 +19,13 @@ module Boa
       #   type.name   # => :admin?
       #
       # @param _name [Symbol] the name of the type
-      # @param includes [Enumerable<Boolean>] the object to check inclusion against
+      # @param includes [Enumerable<Boolean>, nil] the object to check inclusion against
       # @param options [Hash] the options to initialize with
       #
       # @return [void]
       #
       # @api public
-      sig { params(_name: Symbol, includes: T::Array[T::Boolean], options: ::Object).void }
+      sig { params(_name: Symbol, includes: T.nilable(T::Array[T::Boolean]), options: ::Object).void }
       def initialize(_name, includes: DEFAULT_INCLUDES, **options)
         super
       end

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -120,8 +120,7 @@ module Support
         subject = new_object(described_class)
         other   = BasicObject.new
 
-        # refute_equal(...) is not strict enough to kill mutation
-        assert_same(subject == other, false)
+        refute_equal(subject, other)
       end
     end
 
@@ -184,8 +183,8 @@ module Support
         subject = new_object(described_class)
         other   = BasicObject.new
 
-        # refute(...) is not strict enough to kill mutation
-        assert_same(subject.eql?(other), false)
+        # refute_operator does not work with BasicObject and sorbet
+        refute(subject.eql?(other))
       end
     end
 

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -285,6 +285,16 @@ module Support
 
         assert_empty(subject.deconstruct_keys(%i[invalid]))
       end
+
+      sig { void }
+      def test_pattern_matching
+        subject  = new_object(described_class)
+        expected = T.let(expected_object_state, T::Hash[Symbol, T.anything])
+
+        assert_pattern do
+          T.unsafe(subject => expected) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUnsafe
+        end
+      end
     end
 
     module Deconstruct
@@ -308,6 +318,16 @@ module Support
         subject = new_object(described_class)
 
         assert_equal(expected_object_state.values, subject.deconstruct)
+      end
+
+      sig { void }
+      def test_pattern_matching
+        subject  = new_object(described_class)
+        expected = T.let(expected_object_state.values, T::Array[T.anything])
+
+        assert_pattern do
+          T.unsafe(subject => expected) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Sorbet/ForbidTUnsafe
+        end
       end
     end
   end

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -206,7 +206,7 @@ module Support
         subject = new_object(described_class)
         other   = subject.dup
 
-        assert_equal(subject.hash, other.hash)
+        assert_same(subject.hash, other.hash)
       end
 
       sig { override.void }

--- a/test/support/instance_methods_behaviour.rb
+++ b/test/support/instance_methods_behaviour.rb
@@ -55,6 +55,9 @@ module Support
 
       sig { abstract.void }
       def test_objects_similar_but_not_equal_state; end
+
+      sig { abstract.void }
+      def test_non_instance_method_object; end
     end
 
     module Equality
@@ -111,6 +114,15 @@ module Support
       rescue NotImplementedError
         # skip if state_ineql impossible to define for this type
       end
+
+      sig { override.void }
+      def test_non_instance_method_object
+        subject = new_object(described_class)
+        other   = BasicObject.new
+
+        # refute_equal(...) is not strict enough to kill mutation
+        assert_same(subject == other, false)
+      end
     end
 
     module Eql
@@ -166,6 +178,15 @@ module Support
       rescue NotImplementedError
         # skip if state_ineql impossible to define for this type
       end
+
+      sig { override.void }
+      def test_non_instance_method_object
+        subject = new_object(described_class)
+        other   = BasicObject.new
+
+        # refute(...) is not strict enough to kill mutation
+        assert_same(subject.eql?(other), false)
+      end
     end
 
     module Hash
@@ -218,6 +239,14 @@ module Support
         refute_equal(subject.hash, state_ineql.hash)
       rescue NotImplementedError
         # skip if state_ineql impossible to define for this type
+      end
+
+      sig { override.void }
+      def test_non_instance_method_object
+        subject = new_object(described_class)
+        other   = Object.new # BasicObject#hash does not exist
+
+        refute_equal(subject.hash, other.hash)
       end
     end
 

--- a/test/support/strict_matchers.rb
+++ b/test/support/strict_matchers.rb
@@ -1,0 +1,61 @@
+# typed: strong
+# frozen_string_literal: true
+
+module StrictMatchers
+  extend T::Helpers
+  extend T::Sig
+
+  requires_ancestor { Minitest::Test }
+
+  Undefined = Minitest::Assertions::UNDEFINED
+
+  sig { params(test: T::Boolean, msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
+  def assert(test, msg = nil)
+    T.let(super, T::Boolean)
+  end
+
+  sig { params(exp: T.nilable(Object), act: T.nilable(Object), msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
+  def assert_equal(exp, act, msg = nil)
+    T.let(super, T::Boolean)
+  ensure
+    raise_with_clean_backtrace('exp and act cannot be nil, use assert_nil(...) instead')        if exp.nil? || act.nil?
+    raise_with_clean_backtrace('exp and act are the same object, use assert_same(...) instead') if exp.equal?(act)
+  end
+
+  sig { params(exp: T.nilable(Object), act: T.nilable(Object), msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
+  def refute_same(exp, act, msg = nil)
+    T.let(super, T::Boolean)
+  ensure
+    raise_with_clean_backtrace('exp and act cannot be nil, use assert_nil(...) instead')         if exp.nil? || act.nil?
+    raise_with_clean_backtrace('exp and act are the same object, use refute_equal(...) instead') if exp != act
+  end
+
+  sig { params(o1: Object, op: Symbol, o2: Object, msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
+  def assert_operator(o1, op, o2 = Undefined, msg = nil) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Naming/MethodParameterName
+    T.let(super, T::Boolean)
+  ensure
+    raise_with_clean_backtrace('use assert_predicate(...) when testing a predicate') if o2.equal?(Undefined)
+  end
+
+  sig { params(o1: Object, op: Symbol, o2: Object, msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
+  def refute_operator(o1, op, o2 = Undefined, msg = nil) # rubocop:disable Style/DisableCopsWithinSourceCodeDirective,Naming/MethodParameterName
+    T.let(super, T::Boolean)
+  ensure
+    raise_with_clean_backtrace('use refute_predicate(...) when testing a predicate') if o2.equal?(Undefined)
+  end
+
+private
+
+  sig { params(msg: String).returns(T.noreturn) }
+  def raise_with_clean_backtrace(msg)
+    # Remove all lines outside of the project root
+    backtrace = caller
+      .lazy
+      .select { |line| line.start_with?(ROOT_PATH.to_s)         }
+      .reject { |line| line.start_with?(__FILE__)               }
+      .map    { |line| ".#{line.delete_prefix(ROOT_PATH.to_s)}" }
+      .to_a
+
+    raise(RuntimeError, msg, backtrace)
+  end
+end

--- a/test/support/strict_matchers.rb
+++ b/test/support/strict_matchers.rb
@@ -14,6 +14,11 @@ module StrictMatchers
     T.let(super, T::Boolean)
   end
 
+  sig { params(test: T::Boolean, msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
+  def refute(test, msg = nil)
+    T.let(super, T::Boolean)
+  end
+
   sig { params(exp: T.nilable(Object), act: T.nilable(Object), msg: T.nilable(T.any(String, Proc))).returns(T::Boolean) }
   def assert_equal(exp, act, msg = nil)
     T.let(super, T::Boolean)

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -250,6 +250,15 @@ module Support
       end
 
       sig { void }
+      def test_with_nil_includes_option
+        subject = described_class.new(type_name, includes: nil)
+
+        assert_same(type_name, subject.name)
+        assert_nil(subject.includes)
+        assert_predicate(subject, :frozen?)
+      end
+
+      sig { void }
       def test_with_includes_option
         subject = described_class.new(type_name, includes: [])
 

--- a/test/support/type_behaviour.rb
+++ b/test/support/type_behaviour.rb
@@ -222,7 +222,7 @@ module Support
 
         assert_same(type_name, subject.name)
         assert_nil(subject.default)
-        assert_operator(subject, :frozen?)
+        assert_predicate(subject, :frozen?)
       end
 
       sig { void }
@@ -231,14 +231,14 @@ module Support
 
         assert_same(type_name, subject.name)
         assert_same(non_nil_default, subject.default)
-        assert_operator(subject, :frozen?)
+        assert_predicate(subject, :frozen?)
       end
 
       sig { void }
       def test_with_no_includes_option
         subject = described_class.new(type_name)
 
-        assert_equal(type_name, subject.name)
+        assert_same(type_name, subject.name)
 
         if default_includes.nil?
           assert_nil(subject.includes)
@@ -246,16 +246,16 @@ module Support
           assert_equal(default_includes, subject.includes)
         end
 
-        assert_operator(subject, :frozen?)
+        assert_predicate(subject, :frozen?)
       end
 
       sig { void }
       def test_with_includes_option
         subject = described_class.new(type_name, includes: [])
 
-        assert_equal(type_name, subject.name)
+        assert_same(type_name, subject.name)
         assert_empty(subject.includes)
-        assert_operator(subject, :frozen?)
+        assert_predicate(subject, :frozen?)
       end
     end
 
@@ -375,13 +375,13 @@ module Support
         subject.instance_variable_set(:@options,  {})
 
         ivars(subject).each_value do |value|
-          refute_operator(value, :frozen?) unless value.equal?(type_name)
+          refute_predicate(value, :frozen?) unless value.equal?(type_name)
         end
 
         subject.freeze
 
         ivars(subject).each_value do |value|
-          assert_operator(value, :frozen?)
+          assert_predicate(value, :frozen?)
         end
       end
 
@@ -389,7 +389,7 @@ module Support
       def test_freezes_the_type
         subject = described_class.new(type_name)
 
-        assert_operator(subject.freeze, :frozen?)
+        assert_predicate(subject.freeze, :frozen?)
       end
 
       sig { void }
@@ -408,8 +408,8 @@ module Support
         subject.freeze
 
         # Argument is not mutated
-        refute_operator(includes, :frozen?)
-        assert_operator(subject.includes, :frozen?)
+        refute_predicate(includes, :frozen?)
+        assert_predicate(subject.includes, :frozen?)
 
         # Argument state is copied
         refute_same(includes, subject.includes)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,8 @@ require 'minitest/autorun'
 require 'mutant/minitest/coverage'
 require 'sorbet-runtime'
 
-require_relative 'support/mutant_coverage'
 require_relative 'support/instance_methods_behaviour'
+require_relative 'support/mutant_coverage'
 require_relative 'support/type_behaviour'
 
 require 'boa'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,8 +9,12 @@ require 'sorbet-runtime'
 
 require_relative 'support/instance_methods_behaviour'
 require_relative 'support/mutant_coverage'
+require_relative 'support/strict_matchers'
 require_relative 'support/type_behaviour'
 
 require 'boa'
 
+ROOT_PATH = T.let(Pathname.new(__dir__).parent, Pathname)
+
 Minitest::Test.extend(MutantCoverage)
+Minitest::Assertions.prepend(StrictMatchers)

--- a/test/unit/boa/class_methods_test.rb
+++ b/test/unit/boa/class_methods_test.rb
@@ -88,13 +88,13 @@ module Boa
           subject = Class.new(described_class)
 
           ivars(subject).each_value do |value|
-            refute_operator(value, :frozen?)
+            refute_predicate(value, :frozen?)
           end
 
           subject.freeze
 
           ivars(subject).each_value do |value|
-            assert_operator(value, :frozen?)
+            assert_predicate(value, :frozen?)
           end
         end
 
@@ -102,7 +102,7 @@ module Boa
         def test_freezes_the_class
           subject = Class.new(described_class)
 
-          assert_operator(subject.freeze, :frozen?)
+          assert_predicate(subject.freeze, :frozen?)
         end
 
         sig { void }

--- a/test/unit/boa/result_test.rb
+++ b/test/unit/boa/result_test.rb
@@ -143,8 +143,8 @@ module Boa
           unwrapped = subject.unwrap
 
           assert_same(value, unwrapped)
-          assert_operator(subject, :frozen?)
-          assert_operator(unwrapped, :frozen?)
+          assert_predicate(subject, :frozen?)
+          assert_predicate(unwrapped, :frozen?)
         end
 
         sig { override.void }
@@ -154,8 +154,8 @@ module Boa
 
           refute_same(value, unwrapped)
           assert_equal(value, unwrapped)
-          assert_operator(subject, :frozen?)
-          assert_operator(unwrapped, :frozen?)
+          assert_predicate(subject, :frozen?)
+          assert_predicate(unwrapped, :frozen?)
         end
 
         sig { override.void }
@@ -290,7 +290,7 @@ module Boa
             RuntimeError
           )
 
-          assert_equal('Cannot unwrap failure from success', exception.message)
+          assert_same('Cannot unwrap failure from success', exception.message)
         end
       end
 
@@ -370,8 +370,8 @@ module Boa
           unwrapped = subject.unwrap_failure
 
           assert_same(error, unwrapped)
-          assert_operator(subject, :frozen?)
-          assert_operator(unwrapped, :frozen?)
+          assert_predicate(subject, :frozen?)
+          assert_predicate(unwrapped, :frozen?)
         end
 
         sig { override.void }
@@ -381,8 +381,8 @@ module Boa
 
           refute_same(error, unwrapped)
           assert_equal(error, unwrapped)
-          assert_operator(subject, :frozen?)
-          assert_operator(unwrapped, :frozen?)
+          assert_predicate(subject, :frozen?)
+          assert_predicate(unwrapped, :frozen?)
         end
 
         sig { override.void }

--- a/test/unit/boa/type/boolean_test.rb
+++ b/test/unit/boa/type/boolean_test.rb
@@ -35,7 +35,7 @@ module Boa
         sig { void }
         def test_class_hierarchy
           assert_operator(Boa::Type, :>, described_class)
-          assert_equal(Boa::Type::Boolean, described_class)
+          assert_same(Boa::Type::Boolean, described_class)
         end
 
         class ElementReference < self

--- a/test/unit/boa/type/integer_test.rb
+++ b/test/unit/boa/type/integer_test.rb
@@ -35,7 +35,7 @@ module Boa
         sig { void }
         def test_class_hierarchy
           assert_operator(Boa::Type, :>, described_class)
-          assert_equal(Boa::Type::Integer, described_class)
+          assert_same(Boa::Type::Integer, described_class)
         end
 
         class ElementReference < self
@@ -74,7 +74,7 @@ module Boa
 
             assert_same(type_name, subject.name)
             assert_equal(nil.., subject.range)
-            assert_operator(subject, :frozen?)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }
@@ -83,7 +83,7 @@ module Boa
 
             assert_same(type_name, subject.name)
             assert_equal(0..10, subject.range)
-            assert_operator(subject, :frozen?)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }
@@ -92,7 +92,7 @@ module Boa
 
             assert_same(type_name, subject.name)
             assert_equal(..10, subject.range)
-            assert_operator(subject, :frozen?)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }
@@ -101,7 +101,7 @@ module Boa
 
             assert_same(type_name, subject.name)
             assert_equal(1..1, subject.range)
-            assert_operator(subject, :frozen?)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }

--- a/test/unit/boa/type/object_test.rb
+++ b/test/unit/boa/type/object_test.rb
@@ -45,7 +45,7 @@ module Boa
         sig { void }
         def test_class_hierarchy
           assert_operator(Boa::Type, :>, described_class)
-          assert_equal(Boa::Type::Object, described_class)
+          assert_same(Boa::Type::Object, described_class)
         end
 
         class ElementReference < self

--- a/test/unit/boa/type/string_test.rb
+++ b/test/unit/boa/type/string_test.rb
@@ -35,7 +35,7 @@ module Boa
         sig { void }
         def test_class_hierarchy
           assert_operator(Boa::Type, :>, described_class)
-          assert_equal(Boa::Type::String, described_class)
+          assert_same(Boa::Type::String, described_class)
         end
 
         class ElementReference < self
@@ -72,44 +72,44 @@ module Boa
           def test_with_no_length_option
             subject = described_class.new(type_name)
 
-            assert_equal(type_name, subject.name)
+            assert_same(type_name, subject.name)
             assert_equal(0.., subject.length)
-            assert_equal(0, subject.min_length)
+            assert_same(0, subject.min_length)
             assert_nil(subject.max_length)
-            assert_operator(subject, :frozen?)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }
           def test_with_length_option
             subject = described_class.new(type_name, length: 2...10)
 
-            assert_equal(type_name, subject.name)
+            assert_same(type_name, subject.name)
             assert_equal(2..9, subject.length)
-            assert_equal(2, subject.min_length)
-            assert_equal(9, subject.max_length)
-            assert_operator(subject, :frozen?)
+            assert_same(2, subject.min_length)
+            assert_same(9, subject.max_length)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }
           def test_with_length_option_and_nil_minimum_length
             subject = described_class.new(type_name, length: ..10)
 
-            assert_equal(type_name, subject.name)
+            assert_same(type_name, subject.name)
             assert_equal(0..10, subject.length)
-            assert_equal(0, subject.min_length)
-            assert_equal(10, subject.max_length)
-            assert_operator(subject, :frozen?)
+            assert_same(0, subject.min_length)
+            assert_same(10, subject.max_length)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }
           def test_with_length_option_and_singleton_range
             subject = described_class.new(type_name, length: 1..1)
 
-            assert_equal(type_name, subject.name)
+            assert_same(type_name, subject.name)
             assert_equal(1..1, subject.length)
-            assert_equal(1, subject.min_length)
-            assert_equal(1, subject.max_length)
-            assert_operator(subject, :frozen?)
+            assert_same(1, subject.min_length)
+            assert_same(1, subject.max_length)
+            assert_predicate(subject, :frozen?)
           end
 
           sig { void }

--- a/test/unit/boa_test.rb
+++ b/test/unit/boa_test.rb
@@ -60,7 +60,7 @@ module Boa
     sig { void }
     def test_class_hierarchy
       assert_operator(Boa, :>, described_class)
-      assert_equal(Person, described_class)
+      assert_same(Person, described_class)
     end
 
     class New < self
@@ -69,7 +69,7 @@ module Boa
         subject = described_class.new(name: name_value)
 
         assert_instance_of(described_class, subject)
-        assert_equal(name_value, subject.name)
+        assert_same(name_value, subject.name)
       end
     end
 


### PR DESCRIPTION
### Summary

- [x] [Fix InstanceMethods#eql? and #== to accept any object](https://github.com/dkubb/boa/pull/104/commits/b194b42aea9d08df3d489720592041dc01dfd6da)
- [x] [Fix tests to use stricter matchers](https://github.com/dkubb/boa/pull/104/commits/f05c4505afc6e8af62869324be62a781f22b2913)
- [x] [Fix test helper require order](https://github.com/dkubb/boa/pull/104/commits/9af02d21df44f195c82c1cb5adfd9b1419879517)
- [x] [Change Type::Boolean#initialize to allow a nil includes](https://github.com/dkubb/boa/pull/104/commits/87cfc7961c473bda1715848cd23a86c8d79637ad)
- [x] [Add StrictMatchers test support module](https://github.com/dkubb/boa/pull/104/commits/a6a621373ddb212d55719f665cd5720e7b07471d)
- [x] [Add StrictMatchers#refute to ensure boolean values only](https://github.com/dkubb/boa/pull/104/commits/72db67d757ff118e0255e0870be3f91c0b71e434)
- [x] [Add Support::instanceMethodsBehaviour pattern matching tests](https://github.com/dkubb/boa/pull/104/commits/f3b43b645ecc7dc61d45ea3bba781dff7ea6256e)