### PR TITLE
Upgrade sorbet to 0.5.1117

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   gem 'rubocop-sorbet',      '~> 0.7.6', require: false   # Add Sorbet support to RuboCop
   gem 'rubocop-yard',        '~> 0.9.2'                   # RuboCop extension for YARD
   gem 'simplecov',           '~> 0.22.0'                  # Code coverage analysis for Ruby
-  gem 'sorbet',              '~> 0.5.11164'               # Type checker for Ruby
+  gem 'sorbet',              '~> 0.5.11176'               # Type checker for Ruby
   gem 'tapioca',             '~> 0.11.14', require: false # Generate RBI files for gems and standard library
   gem 'unparser',            '~> 0.6.10', require: false  # Library for unparsing Ruby expressions
   gem 'yard-doctest',        '~> 0.1.17'                  # Run doctests via YARD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,4 +150,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.3
+   2.5.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     boa (0.1.0)
-      sorbet-runtime (~> 0.5.11163)
+      sorbet-runtime (~> 0.5.11176)
 
 GEM
   remote: https://oss:sxCL1o1navkPi2XnGB5WYBrhpY9iKIPL@gem.mutant.dev/
@@ -79,14 +79,14 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.11164)
-      sorbet-static (= 0.5.11164)
-    sorbet-runtime (0.5.11164)
-    sorbet-static (0.5.11164-universal-darwin)
-    sorbet-static (0.5.11164-x86_64-linux)
-    sorbet-static-and-runtime (0.5.11164)
-      sorbet (= 0.5.11164)
-      sorbet-runtime (= 0.5.11164)
+    sorbet (0.5.11176)
+      sorbet-static (= 0.5.11176)
+    sorbet-runtime (0.5.11176)
+    sorbet-static (0.5.11176-universal-darwin)
+    sorbet-static (0.5.11176-x86_64-linux)
+    sorbet-static-and-runtime (0.5.11176)
+      sorbet (= 0.5.11176)
+      sorbet-runtime (= 0.5.11176)
     spoom (1.2.4)
       erubi (>= 1.10.0)
       sorbet-static-and-runtime (>= 0.5.10187)
@@ -139,7 +139,7 @@ DEPENDENCIES
   rubocop-sorbet (~> 0.7.6)
   rubocop-yard (~> 0.9.2)
   simplecov (~> 0.22.0)
-  sorbet (~> 0.5.11164)
+  sorbet (~> 0.5.11176)
   tapioca (~> 0.11.14)
   unparser (~> 0.6.10)
   yard-doctest (~> 0.1.17)

--- a/boa.gemspec
+++ b/boa.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 3.3.0'
 
-  spec.add_dependency('sorbet-runtime', '~> 0.5.11163')
+  spec.add_dependency('sorbet-runtime', '~> 0.5.11176')
 end


### PR DESCRIPTION
### Summary

- [x] [Upgrade sorbet to 0.5.11176](https://github.com/dkubb/boa/pull/105/commits/92644be4a7353cf65a857b65bfdc42d7d8e46236)
- [x] [Upgrade Gemfile.lock bundler version to 2.5.4](https://github.com/dkubb/boa/pull/105/commits/9230e5512c173dc2bb56d5adb435cf7b8d8fb101)
